### PR TITLE
Updated collision-coalescence.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build
 case1
+*.suo
+*.json
+*.sqlite

--- a/defs.F
+++ b/defs.F
@@ -10,7 +10,7 @@ c     ----------------------------------------------------------------------
      +     icouple,iTcouple,iHcouple,ievap,ifields,ilin,ineighbor,
      +     icoalesce,ipart_method,ipartdiff,isfs,iexner,ilongwave,
      +     inetcdf,iviznetcdf,ihumiditycontrol,ireintro,itrajout,
-     +     inewpart,ihurr,icase
+     +     inewpart,ihurr,icase,ikernel
 
       real :: max_time
 c     

--- a/les.F
+++ b/les.F
@@ -10387,7 +10387,7 @@ c
      +         ineighbor,icoalesce,ipart_method,inewpart,icase,
      +         ipartdiff,isfs,iexner,ilongwave,ihurr,
      +         inetcdf,iviznetcdf,ihumiditycontrol,ireintro,
-     +         itrajout
+     +         itrajout, ikernel
 
 
       namelist /constants/ rhoa, nuf, Cpa, Pra, Sc,

--- a/params.in
+++ b/params.in
@@ -28,6 +28,7 @@ iHcouple=1  !iHcouple also controls TE couple
 ievap=1
 ineighbor=0
 icoalesce=0
+ikernel = 1 ! kernel for coalescence; 0 = Golovin; 1 = Geometric kernel with collection efficiencies E=1; 2 = Long kernel; 3 = Geometric kernel with modified Hall collection efficiencies (as in Bott 1998); 4 = Geometric kernel with turbulence-enhanced Hall efficiencies (Wang and Grabowski 2009) (NOT YET)
 ipart_method=2   !1 = same RK3 as flow, 2 = backward Euler
 ipartdiff = 0
 inewpart = 2  !1 = new particles have initial conditions defined below, random location in domain; 2 = same, but normal distributions of radius and kappa_s, given by radius_std and kappas_std; 3 = special setup for C-FOG and double lognormal of different type; 4 = crude sea spray setup


### PR DESCRIPTION
-Added variable ikernel to params.in and particles.f90. It allows to choose which collision kernel you want to use.

-Added Long 1974 collection efficiencies, based on the work of Bott 1998. It can be found on function long_effic.

-Added collection efficiencies of Hall 1980, modified by Bott 1998. It can be found in function hall_effic.

-Now the solute mass and kappa (higroscopicity) coefficient are updated due to collision-coalescence in sr. particle_coalesce.