### PR TITLE
Adapted code to be able to use two solute types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,43 @@
 FORTRAN=mpif90
 F90=ifort
 
-FLAGS=-i4 -r8 -O2 -assume byterecl -xHost
+FLAGS=-i4 -r8 -O2 -assume byterecl -xHost -fpp
 
 ## UNCOMMENT TO RUN IN DEBUG MODE
-# DEBUG_FLAGS=-g -traceback -check bounds
+DEBUG_FLAGS=-g -traceback
+#DEBUG_FLAGS+=-check bounds
+
+##UNCOMMENT TO RUN WITH TECPLOT I/O
+#Provide location of the mpi-enabled tecio library
+#TECINCLUDE=~/Research/tecio/libteciompi.a
+#TECLINK=-lm -lstdc++ -lgcc_eh -DTECIO
 
 OUTPUTINC = -I$(NETCDFBASE)/include
 OUTPUTLIB = -L$(NETCDFBASE)/lib
-OUTPUTOPT = -DNETCDF -DNCFPLUS
 LINKOPTS  = -lnetcdf -lnetcdff
+
 
 SRC = 	fft.f \
 	kdtree.f90 \
         defs.F \
         particles.f90\
-        netcdf_io.f90
+        netcdf_io.f90\
+        tec_io.f90
 
 OBJS = $(addsuffix .o, $(basename $(SRC)))
 
 
 lesmpi.a: $(OBJS) les.F
-	$(FORTRAN) $^ -o $@  $(FLAGS) $(DEBUG_FLAGS) $(OUTPUTINC) $(OUTPUTLIB) $(LINKOPTS)
+	$(FORTRAN) $^ -o $@  $(FLAGS) $(DEBUG_FLAGS) $(OUTPUTINC) $(OUTPUTLIB) $(LINKOPTS) $(TECLINK) $(TECINCLUDE)
 
 %.o: %.f
-	$(FORTRAN) $(FLAGS) $(DEBUG_FLAGS) -c $< $(OUTPUTINC) $(OUTPUTLIB)
+	$(FORTRAN) $(FLAGS) $(DEBUG_FLAGS) -c $< $(OUTPUTINC) $(OUTPUTLIB) $(TECLINK)
 
 %.o: %.f90
-	$(FORTRAN) $(FLAGS) $(DEBUG_FLAGS) -c $< $(OUTPUTINC) $(OUTPUTLIB)
+	$(FORTRAN) $(FLAGS) $(DEBUG_FLAGS) -c $< $(OUTPUTINC) $(OUTPUTLIB) $(TECLINK)
 
 %.o: %.F
-	$(FORTRAN) $(FLAGS) $(DEBUG_FLAGS) -c $< $(OUTPUTINC) $(OUTPUTLIB)
+	$(FORTRAN) $(FLAGS) $(DEBUG_FLAGS) -c $< $(OUTPUTINC) $(OUTPUTLIB) $(TECLINK)
 
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 FORTRAN=mpif90
 F90=ifort
 
-FLAGS=-i4 -r8 -O2 -assume byterecl -xHost -fpp
+## UNCOMMENT ONLY IF RUNNING IN HPC OR LONG QUEUE
+FLAGS=-i4 -r8 -O2 -assume byterecl -fpp
+
+## UNCOMMENT IF RUNNING IN RICHTER QUEUE
+#FLAGS=-i4 -r8 -O2 -assume byterecl -xHost -fpp
 
 ## UNCOMMENT TO RUN IN DEBUG MODE
 DEBUG_FLAGS=-g -traceback

--- a/les.F
+++ b/les.F
@@ -633,8 +633,8 @@ c
 
       end do
 
-      if (tauc/10.0 .lt. dt_new) then
-            dt_new = tauc/10.0
+      if (tauc/15.0 .lt. dt_new) then
+            dt_new = tauc/15.0
             if (l_root) then
             write(6,6210) dt_new, dt_cfl, tauc
  6210       format(' 6210 cfl time step too large for droplets',/,

--- a/les.F
+++ b/les.F
@@ -6,6 +6,9 @@ c
       use con_data
       use con_stats
       use netcdf_io
+#ifdef TECIO
+      use tec_io
+#endif
       include 'mpif.h'
 c
 c ------------- definition of internal flags
@@ -105,6 +108,10 @@ c
          call particle_init 
          !call read_part_res !comment out usually 
 
+#ifdef TECIO
+         call init_tecio
+#endif
+
 c
 c ---------- choose routine for getting initial guess
 c
@@ -134,6 +141,10 @@ c
  
          call particle_setup
          call read_part_res
+
+#ifdef TECIO
+         call init_tecio
+#endif
 
          if (inetcdf .eq. 1) then
          call netcdf_res
@@ -282,6 +293,7 @@ c
             call save_viz(it)
          end if
       endif
+
 c
 c ------------ save pressure field
 c
@@ -426,6 +438,13 @@ c
          end if
       end if
 
+#ifdef TECIO
+      if (mod(it,20000) .eq. 0) then
+      !if (time .gt. 200.0 .and. time .lt. 205.0) then
+      call plt_fields
+      end if
+#endif
+
       call get_max
       call get_dt
       if (it.ge.itmax) go to 99000
@@ -434,9 +453,15 @@ c
          itmax = floor(real(it)/real(itape))*itape + itape  !Stop at next itape
       end if
 
+
       go to 9000
 c
 99000 continue
+
+#ifdef TECIO
+      call finalize_tecio
+#endif
+
       te_mpi = mpi_wtime()
       write(6,9997) (te_mpi - ts_mpi)
  9997 format(' Job Execution Time = ',e15.6)
@@ -3536,7 +3561,7 @@ c
         enddo
         do iscl=1,nscl
 c
-c ---------- first get average scalar gradient
+c ---------- get average scalar gradient
 c
            dtdzf(iscl) = 0.0
            do iy=iys,iye
@@ -3580,6 +3605,7 @@ c
       enddo
       enddo
       call mpi_sum_xy(xmeanp,myid,iss,ise,1)
+
       do iscl=1,nscl
          do iy=iys,iye
          do ix=1,nnx
@@ -5952,6 +5978,8 @@ c
            do ix=1,nnx
               t(ix,iy,1,iz) = t_surf + slope_t*zz(iz)
               t(ix,iy,2,iz) = q_surf + slope_q*zz(iz)
+              !t(ix,iy,2,iz) = 0.0105 
+              !t(ix,iy,1,iz) = 285.0
            enddo
            enddo
          elseif(zz(iz) .ge. z_switch) then
@@ -7267,9 +7295,9 @@ c
       vp1msqr(iz) = stat(iz,15)/stat(iz,11)-vp1mean(iz)**2
       vp2msqr(iz) = stat(iz,16)/stat(iz,11)-vp2mean(iz)**2
       vp3msqr(iz) = stat(iz,17)/stat(iz,11)-vp3mean(iz)**2
-      m1src(iz) = -stat(iz,18)*fnxy
-      m2src(iz) = -stat(iz,19)*fnxy
-      m3src(iz) = -stat(iz,20)*fnxy
+      m1src(iz) = stat(iz,18)*fnxy
+      m2src(iz) = stat(iz,19)*fnxy
+      m3src(iz) = stat(iz,20)*fnxy
       uw_tot(iz) = uwle(iz) + uwsb(iz)
       vw_tot(iz) = vwle(iz) + vwsb(iz)
       upwpm(iz) = stat(iz,21)/stat(iz,11)-(vp1mean(iz)*vp3mean(iz))
@@ -7278,7 +7306,7 @@ c
       Tfmean(iz) = stat(iz,24)/stat(iz,11)
       qfmean(iz) = stat(iz,25)/stat(iz,11)
       wpTpm(iz) = stat(iz,26)/stat(iz,11)-(Tpmean(iz)*vp3mean(iz))
-      Tpsrc(iz) = -stat(iz,27)*fnxy
+      Tpsrc(iz) = stat(iz,27)*fnxy
       radmean(iz) = stat(iz,28)/stat(iz,11) 
       rad2mean(iz)= stat(iz,29)/stat(iz,11)
  
@@ -7287,8 +7315,8 @@ c
       Nc(iz) = stat(iz,30)/xl/yl/dzw(iz)
       ql(iz) = stat(iz,31)/xl/yl/dzw(iz)/rhoa
  
-      Hpsrc(iz) = -stat(iz,32)*fnxy
-      TEpsrc(iz) = -stat(iz,33)*fnxy
+      Hpsrc(iz) = stat(iz,32)*fnxy
+      TEpsrc(iz) = stat(iz,33)*fnxy
       qstarm(iz) = stat(iz,34)/stat(iz,11)
 
       RHxym(iz) = stat(iz,35)*fnxy
@@ -10316,7 +10344,7 @@ c
 
 
       if (ihumiditycontrol) then
-          meanRH_target = 103.0
+          meanRH_target = 102.0
           Swall = Swall + (meanRH_target - meanRH_curr)*1.0e-9
       end if
 

--- a/les.run
+++ b/les.run
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-#$ -M drichte2@nd.edu
+#$ -M crodri25@nd.edu
 #$ -m n
 #$ -pe mpi-16 64
 #$ -q *@@richter
-#$ -N Theo_Pi_1
+#$ -N CFOGtest
 #$ -j y
 
-case=case1
+case=case0
 time=0000000
 runout=$case.out.$time
 
-datadir=/scratch365/drichte2/Theo_Pi/$case
-homedir=~/Research/Theo_Pi/$case
+datadir=/scratch365/crodri25/development/CFOG/$case
+homedir=~/development/CFOG/$case
 
 cd $homedir
 
@@ -24,6 +24,6 @@ imachine=0
 echo $imachine > ./mach.file
 echo $datadir >> ./mach.file
 
-mpirun -n 64 $homedir/../lesmpi.a $homedir/params.in > $datadir/$runout
+mpirun -n 64 $homedir/lesmpi.a $homedir/params.in > $datadir/$runout
 
 

--- a/params.in
+++ b/params.in
@@ -2,24 +2,24 @@
 !Time step information
 &step_params
 iti=0          !Time step to begin
-itmax=150000   !Max number of time steps
-imean=100    !Number of time steps between writing mean profiles to output log file
-ihst=20     !Number of time steps between writing profiles to history file
-itape=2000  !Number of time steps before opening new history file and writing full 3D volumes
-i_viz=500   !Time steps between writing to viz file
+itmax=100000   !Max number of time steps
+imean=10    !Number of time steps between writing mean profiles to output log file
+ihst=10     !Number of time steps between writing profiles to history file
+itape=100  !Number of time steps before opening new history file and writing full 3D volumes
+i_viz=10   !Time steps between writing to viz file
 itn = 0  !Index for "u.le.cou001" files
-max_time = 1.0  !Code will stop at the next itape after this time (in seconds) has been exceeded
+max_time = 10.0  !Code will stop at the next itape after this time (in seconds) has been exceeded
 /
 
 !Flags for various features
 &flags
 ismlt=0, ifree=0, iradup=0, iupwnd=1
 ibuoy=1, ifilt=0, itcut=1, isubs=0, ibrcl=0, iocean=0
-method=3, idebug=1, ivis0=1, ifix_dt=1, new_vis=-1
+method=3, idebug=1, ivis0=1, ifix_dt=0, new_vis=-1
 isfc = 1, 1  ! isfc = 0 sets surface flux (qstar), isfc = 1 sets surface condition (Dirichlet through tsfcc)
-iz_space=1, ! 0 = uniform dz, 1 = top/bottom mirror stretched ("channel"), 2 = "open channel", 3 = PBL with stretching at surface and at zi
-iDNS = 1
-ifields = 1  ! if set to 1, reads the initial condition from path_ran below; otherwise calls subroutine random
+iz_space=2, ! 0 = uniform dz, 1 = top/bottom mirror stretched ("channel"), 2 = "open channel", 3 = PBL with stretching at surface and at zi
+iDNS = 0
+ifields = 0  ! if set to 1, reads the initial condition from path_ran below; otherwise calls subroutine random
 ihurr = 0  !If set to 1, includes the hurricane forcings from Bryan et al. (2017) BLM and according to dvdr and hurr_rad below
 ilin = 1   !1 means linear interpolation for particle, 6th order otherwise
 icouple=1
@@ -27,15 +27,15 @@ iTcouple=1
 iHcouple=1  !iHcouple also controls TE couple
 ievap=1
 ineighbor=0
-icoalesce=0
-ikernel = 1 ! kernel for coalescence; 0 = Golovin; 1 = Geometric kernel with collection efficiencies E=1; 2 = Long kernel; 3 = Geometric kernel with modified Hall collection efficiencies (as in Bott 1998); 4 = Geometric kernel with turbulence-enhanced Hall efficiencies (Wang and Grabowski 2009) (NOT YET)
+icoalesce=1
+ikernel = 3 ! kernel for coalescence; 0 = Golovin; 1 = Geometric kernel with collection efficiencies E=1; 2 = Long kernel; 3 = Geometric kernel with modified Hall collection efficiencies (as in Bott 1998); 4 = Geometric kernel with turbulence-enhanced Hall efficiencies (Wang and Grabowski 2009) (NOT YET)
 ipart_method=2   !1 = same RK3 as flow, 2 = backward Euler
-ipartdiff = 0
-inewpart = 2  !1 = new particles have initial conditions defined below, random location in domain; 2 = same, but normal distributions of radius and kappa_s, given by radius_std and kappas_std; 3 = special setup for C-FOG and double lognormal of different type; 4 = crude sea spray setup
+ipartdiff = 1
+inewpart = 3  !1 = new particles have initial conditions defined below, random location in domain; 2 = same, but normal distributions of radius and kappa_s, given by radius_std and kappas_std; 3 = special setup for C-FOG and double lognormal of different type; 4 = crude sea spray setup
 icase = 3  !Special additions for certain cases. 3 = setup for C-FOG, 4 = steady state LES sea spray setup
 isfs = 2   !isfs=1 is simple random walk, isfs=2 is Weil et al. (2004) particle subgrid
-iexner = 0  !iexner = 1 applies a correction to part%Tf to account for conversion b/w potential temp and temp. (need in PBL)
-ilongwave = 0   !Use simple longwave radiation scheme when clouds/fog present
+iexner = 1  !iexner = 1 applies a correction to part%Tf to account for conversion b/w potential temp and temp. (need in PBL)
+ilongwave = 1   !Use simple longwave radiation scheme when clouds/fog present
 inetcdf = 1  !Set to 1 to output history and histogram data to netcdf format, otherwise original binary format
 iviznetcdf = 1  !Set to 1 to slice viz files to netcdf format (WARNING: it's been a long time since the original have been used)
 ihumiditycontrol = 0  !Adaptive humidity source/sink (used for Pi Chamber; subroutine humidity_control)
@@ -67,12 +67,12 @@ psurf = 101325  !Pa -- nominal surface pressure, for use in the definition of po
 
 ugcont = 4.0   !The initial u-velocity in the field
 vgcont = 0.0   !The initial v-velocity
-dvdr = -8.0e-04  !Change in v with hurricane radius
-hurr_rad = 40e3  ! Hurricane radius
+dvdr = 0.0  !Change in v with hurricane radius
+hurr_rad = 0.0  ! Hurricane radius
 
 dpdx = 0.0  !The pressure gradient for channel flow (gets put into u_geo for DNS)
 
-Swall = -2.15e-6  !Set the CONSTANT humidity sink to use if ihumiditycontrol = 0
+Swall = 0.0  !Set the CONSTANT humidity sink to use if ihumiditycontrol = 0
 
 zi = 80.0  !This has to do with grid stretching; make equal to zl for iz_space = 1,2; zi is inversion height for iz_space = 3
 zl = 80.0
@@ -90,10 +90,10 @@ rad_Fcb = 0.0    !Net radiative flux at cloud (or domain) base
 
 !Set the paths for code I/O. Must be on the scratch directory, not AFS!
 &path_names
-path_seed="/scratch365/drichte2/Theo_Pi/case1/"
-path_part="/scratch365/drichte2/Theo_Pi/case1/part.le.cou000"
-path_res="/scratch365/drichte2/Theo_Pi/case1/u.le.cou000"
-path_ran="/scratch365/drichte2/Theo_Pi/case1/u.le.cou000"
+path_seed="/scratch365/crodri25/development/CFOG/case0/"
+path_part="/scratch365/crodri25/development/CFOG/case0/part.le.cou000"
+path_res="/scratch365/crodri25/development/CFOG/case0/u.le.cou000"
+path_ran="/scratch365/crodri25/development/CFOG/case0/u.le.cou000"
 /
 
 

--- a/particles.f90
+++ b/particles.f90
@@ -76,7 +76,7 @@ module particles
   real :: hist_numact(histbins+2)
   real :: bins_numact(histbins+2)
 
-  !REMEMBER: IF ADDING ANYTHING, MUST UPDATE MPI DATATYPE!
+  !REMEMBER: IF ADDING ANYTHING, MUST UPDATE MPI DATATYPE (sr. particle_setup)!
   type :: particle
     integer :: pidx,procidx,nbr_pidx,nbr_procidx
     real :: vp(3),xp(3),uf(3),xrhs(3),vrhs(3),Tp,Tprhs_s
@@ -1787,7 +1787,7 @@ CONTAINS
       !Set up MPI datatypes for sending particle information
       !MUST UPDATE IF THINGS ARE ADDED/REMOVED FROM PARTICLE STRUCTURE
 
-      num_reals = 6*3+16
+      num_reals = 6*3+17
       num_integers = 4
       num_longs = 3
       
@@ -3711,7 +3711,7 @@ CONTAINS
 
          kappa_s_data(i) = part_tmp%kappa_s
          ms_data(i) = part_tmp%m_s
-         vol_s_data(i) = part%vol_s
+         vol_s_data(i) = part_tmp%vol_s
 
          vel_data(i,1:3) = part_tmp%vp(1:3)
 
@@ -3858,7 +3858,6 @@ CONTAINS
 			      !Volume mixing rule (Petter and Kreindenweis 2007, kappa_s = sum(e_i*kappa_si))
 			      kappa_s_data(k_idx) = gam_til*vol_s_data(j_idx)*kappa_s_data(j_idx)/( gam_til*vol_s_data(j_idx) + vol_s_data(k_idx))  +   &
                 vol_s_data(k_idx)*kappa_s_data(k_idx) / ( gam_til*vol_s_data(j_idx) + vol_s_data(k_idx))
- 
                
 
             elseif (xi_j - gam_til*xi_k .eq. 0) then
@@ -3898,9 +3897,7 @@ CONTAINS
    
                kappa_s_data(j_idx) = kappa_s_j_temp
                kappa_s_data(k_idx) = kappa_s_k_temp
-   
  
-
             end if
           end if !gm .gt. 0
 

--- a/tec_io.f90
+++ b/tec_io.f90
@@ -1,0 +1,557 @@
+module tec_io
+implicit none
+
+
+integer :: plt_counter
+character(len=:),allocatable :: path_plt,data_names
+character*1 :: nullchr
+integer :: sharevar(11),null(11),nodeloc(11),passive(11)
+integer :: teci,filetype,debug,fileformat,isdouble
+
+CONTAINS
+
+subroutine init_tecio
+  use pars
+  implicit none
+  include 'mpif.h'
+
+  integer ::  tecini142,tecmpiinit142
+
+  data_names = 'x y z u v w th q rh tp rp'
+
+  path_plt = trim(trim(path_seed)//"tec_viz.szplt")
+
+  nullchr = char(0)
+  null = 0
+  isdouble = 0
+  fileformat = 1
+  filetype = 0
+  debug = 1
+
+  plt_counter = 1
+
+#ifdef TECIO
+
+  teci = tecini142('veldata'//nullchr,&
+       data_names//nullchr,&
+       path_plt//nullchr,&
+       trim(path_seed)//nullchr,&
+       fileformat,&
+       filetype,&
+       debug,&
+       isdouble)
+
+  teci = tecmpiinit142(mpi_comm_world,0)
+
+#endif
+
+end subroutine init_tecio
+subroutine finalize_tecio
+  implicit none
+
+  integer :: tecend142
+
+#ifdef TECIO
+  teci = tecend142()  
+#endif
+
+end subroutine finalize_tecio
+
+subroutine plt_fields
+  use particles
+  use fields
+  use pars
+  use con_stats
+  use con_data
+  implicit none
+  include 'mpif.h'
+
+  integer :: i,j,k,kmin,kmax,jmin,jmax,ip
+  integer :: myny,mynz,mynp,npsize,nps,npe,tnumpart_tec
+  integer :: rankarray(numprocs),nparray(numprocs)
+  integer :: ierr
+  integer :: teczne142,tecdat142,tecend142,tecznemap142,tecijkptn142
+  real :: plt_time
+
+  real,allocatable :: uplt(:,:,:),vplt(:,:,:),wplt(:,:,:),wtmp(:,:,:),tplt(:,:,:),qplt(:,:,:),rhplt(:,:,:),xplt(:,:,:),yplt(:,:,:),zplt(:,:,:)
+  real*4,allocatable :: toplt(:,:,:),xpart(:),ypart(:),zpart(:),upart(:),vpart(:),wpart(:),tpart(:),rpart(:)
+
+  plt_time = time
+
+  kmin = izs
+  kmax = min(ize+1,nnz)
+  jmin = max(iys-1,1)
+  jmax = iye
+
+#ifdef TECIO
+
+  allocate(uplt(1:nnx,jmin:jmax,kmin:kmax),vplt(1:nnx,jmin:jmax,kmin:kmax),wplt(1:nnx,jmin:jmax,kmin:kmax),wtmp(1:nnx,jmin:jmax,kmin:kmax),tplt(1:nnx,jmin:jmax,kmin:kmax),qplt(1:nnx,jmin:jmax,kmin:kmax),rhplt(1:nnx,jmin:jmax,kmin:kmax),xplt(1:nnx,jmin:jmax,kmin:kmax),yplt(1:nnx,jmin:jmax,kmin:kmax),zplt(1:nnx,jmin:jmax,kmin:kmax),toplt(1:nnx,jmin:jmax,kmin:kmax))
+
+  call fill_plt_fields(jmin,jmax,kmin,kmax,uplt,vplt,wtmp,tplt,qplt,rhplt)
+
+
+  do k=kmin,kmax
+  do j=jmin,jmax
+  do i=1,nnx
+
+     if (k==1) then
+        wplt(i,j,k) = 0.5*wtmp(i,j,k)
+     else
+        wplt(i,j,k) = 0.5*(wtmp(i,j,k)+wtmp(i,j,k-1))
+     end if
+
+  end do
+  end do
+  end do
+
+  myny = jmax-jmin+1
+  mynz = kmax-kmin+1
+
+  do i=0,numprocs-1
+     rankarray(i+1) = i
+  end do
+
+  !Fill x,y,z:
+  do k=kmin,kmax
+     do j=jmin,jmax
+        do i=1,nnx
+           xplt(i,j,k) = dx*(i-1)
+           yplt(i,j,k) = dy*(j-1)
+           zplt(i,j,k) = zz(k)
+        end do
+     end do
+  end do
+
+  passive = 1
+  passive(1:9) = 0
+  if (plt_counter == 1) then
+    sharevar = 0
+  else
+    sharevar = 0
+    sharevar(1:3) = 1
+  end if
+  nodeloc = 1
+
+  teci = teczne142('FLOW'//nullchr,&
+       0,&              !0 = ordered data
+       nnx,&             !num elements in first direction
+       nny,&             !num elements in second direction
+       nnz,&             !num elements in third direction
+       0,&              !ICellMax (don't use)
+       0,&              !JCellMax (don't use)
+       0,&              !KCellMax (don't use)
+       plt_time,&       !time stamp
+       1,&              !strandid
+       0,&              !parent zone
+       1,&              !0=point, 1=block
+       0,&              !numfaceconnections
+       0,&              !faceneighbormode
+       1,&              !totalnumfacenodes
+       1,&              !numconnectedboundaryfaces
+       1,&              !totalnumboundaryconnections
+       passive,&        !passivevarlist
+       nodeloc,&        !valuelocation, null means centered
+       sharevar,&       !sharevarzone, share variable from zone
+       0)
+
+  
+  teci = tecznemap142(numprocs,rankarray)
+
+  teci = tecijkptn142(myid+1,&
+       1,&
+       jmin,&
+       kmin,&
+       nnx,&
+       jmax,&
+       kmax)
+
+  if (plt_counter == 1) then
+
+  toplt = xplt(1:nnx,jmin:jmax,kmin:kmax)
+  teci = tecdat142(nnx*myny*mynz,toplt(1:nnx,jmin:jmax,kmin:kmax),isdouble)
+
+  toplt = yplt(1:nnx,jmin:jmax,kmin:kmax)
+  teci = tecdat142(nnx*myny*mynz,toplt(1:nnx,jmin:jmax,kmin:kmax),isdouble)
+
+  toplt = zplt(1:nnx,jmin:jmax,kmin:kmax)
+  teci = tecdat142(nnx*myny*mynz,toplt(1:nnx,jmin:jmax,kmin:kmax),isdouble)
+
+  end if
+
+  toplt = uplt(1:nnx,jmin:jmax,kmin:kmax)
+  teci = tecdat142(nnx*myny*mynz,toplt(1:nnx,jmin:jmax,kmin:kmax),isdouble)
+
+  toplt = vplt(1:nnx,jmin:jmax,kmin:kmax)
+  teci = tecdat142(nnx*myny*mynz,toplt(1:nnx,jmin:jmax,kmin:kmax),isdouble)
+
+  toplt = wplt(1:nnx,jmin:jmax,kmin:kmax)
+  teci = tecdat142(nnx*myny*mynz,toplt(1:nnx,jmin:jmax,kmin:kmax),isdouble)
+
+  toplt = tplt(1:nnx,jmin:jmax,kmin:kmax)
+  teci = tecdat142(nnx*myny*mynz,toplt(1:nnx,jmin:jmax,kmin:kmax),isdouble)
+
+  toplt = qplt(1:nnx,jmin:jmax,kmin:kmax)
+  teci = tecdat142(nnx*myny*mynz,toplt(1:nnx,jmin:jmax,kmin:kmax),isdouble)
+
+  toplt = rhplt(1:nnx,jmin:jmax,kmin:kmax)
+  teci = tecdat142(nnx*myny*mynz,toplt(1:nnx,jmin:jmax,kmin:kmax),isdouble)
+
+  !Now get the particle locations to put into the *.plt file:
+
+  passive = 0
+  passive(7:9) = 1
+  sharevar = 0
+
+  mynp = numpart  !From the last time particle number was calculated
+
+  if (myid .eq. 0) then
+     npsize=mynp
+  else
+     npsize=mynp+1
+  end if
+
+  if (tnumpart .eq. 0) then
+     tnumpart_tec = 1
+  else
+     tnumpart_tec = tnumpart
+  end if
+
+  !allocate(xpart(npsize),ypart(npsize),zpart(npsize),upart(npsize),vpart(npsize),wpart(npsize),tpart(npsize),rpart(npsize))
+  allocate(xpart(tnumpart_tec),ypart(tnumpart_tec),zpart(tnumpart_tec),upart(tnumpart_tec),vpart(tnumpart_tec),wpart(tnumpart_tec),tpart(tnumpart_tec),rpart(tnumpart_tec))
+  
+
+  !Need the beginning and end index of particle number for each proc
+  call mpi_allgather(mynp,1,mpi_integer,nparray,1,mpi_integer,mpi_comm_world,ierr)
+
+  if (myid .eq. 0) then
+     nps=1
+     npe = mynp
+  else
+    nps = 0
+    do ip = 1,myid
+       nps = nps + nparray(ip) 
+    end do
+    npe = nps + mynp
+  end if
+
+  !call fill_plt_part(npsize,xpart,ypart,zpart,upart,vpart,wpart,tpart,rpart)
+
+  if (tnumpart .eq. 0) then
+     xpart(1) = 0.0
+     ypart(1) = 0.0
+     zpart(1) = 0.0
+     upart(1) = 0.0
+     vpart(1) = 0.0
+     wpart(1) = 0.0
+     tpart(1) = 0.0
+     rpart(1) = 0.0
+  else
+     call fill_plt_part_ROOT(nparray,xpart,ypart,zpart,upart,vpart,wpart,tpart,rpart)
+  end if
+
+  if (myid .eq. 0) then
+
+
+  teci = teczne142('PART'//nullchr,&
+       0,&              !0 = ordered data
+       tnumpart_tec,&       !num elements in first direction
+       1,&              !num elements in second direction
+       1,&              !num elements in third direction
+       0,&              !ICellMax (don't use)
+       0,&              !JCellMax (don't use)
+       0,&              !KCellMax (don't use)
+       plt_time,&       !time stamp
+       1,&              !strandid
+       0,&              !parent zone
+       1,&              !0=point, 1=block
+       0,&              !numfaceconnections
+       0,&              !faceneighbormode
+       0,&              !totalnumfacenodes
+       0,&              !numconnectedboundaryfaces
+       0,&              !totalnumboundaryconnections
+       passive,&        !passivevarlist
+       nodeloc,&        !valuelocation, null means centered
+       sharevar,&       !sharevarzone, share variable from zone
+       0)  
+
+  teci = tecznemap142(1,0)
+
+  !teci = tecijkptn142(myid+1,&
+  !     nps,&
+  !     1,&
+  !     1,&
+  !     npe,&
+  !     1,&
+  !     1)
+
+  teci = tecdat142(tnumpart_tec,xpart,isdouble)
+  teci = tecdat142(tnumpart_tec,ypart,isdouble)
+  teci = tecdat142(tnumpart_tec,zpart,isdouble)
+  teci = tecdat142(tnumpart_tec,upart,isdouble)
+  teci = tecdat142(tnumpart_tec,vpart,isdouble)
+  teci = tecdat142(tnumpart_tec,wpart,isdouble)
+  teci = tecdat142(tnumpart_tec,tpart,isdouble)
+  teci = tecdat142(tnumpart_tec,rpart,isdouble)
+
+  end if
+
+  plt_counter = plt_counter + 1
+
+
+  deallocate(uplt,vplt,wplt,wtmp,tplt,qplt,rhplt,xplt,yplt,zplt,toplt)
+  deallocate(xpart,ypart,zpart,upart,vpart,wpart,tpart,rpart)
+
+#ENDIF
+
+end subroutine plt_fields
+subroutine fill_plt_fields(jmin,jmax,kmin,kmax,uplt,vplt,wtmp,tplt,qplt,rhplt)
+use pars
+use fields
+use con_stats
+implicit none
+include 'mpif.h'
+
+real, intent(inout) :: uplt(1:nnx,jmin:jmax,kmin:kmax),vplt(1:nnx,jmin:jmax,kmin:kmax),wtmp(1:nnx,jmin:jmax,kmin:kmax),tplt(1:nnx,jmin:jmax,kmin:kmax),qplt(1:nnx,jmin:jmax,kmin:kmax),rhplt(1:nnx,jmin:jmax,kmin:kmax)
+integer, intent(in) :: jmin,jmax,kmin,kmax
+integer :: yfore,yback,nsend,nrecv
+integer :: ix,iy,iz,jloc,iscl
+integer :: ierr,istatus(mpi_status_size)
+real :: sendbuf(1:nnx,kmin:kmax,6),recvbuf(1:nnx,kmin:kmax,6)
+real :: Ttmp,mod_magnus
+
+  !First fill everything except y-halo
+  do iz=kmin,kmax
+  do iy=iys,iye
+  do ix=1,nnx
+     uplt(ix,iy,iz) = u(ix,iy,iz)
+     vplt(ix,iy,iz) = v(ix,iy,iz)
+     wtmp(ix,iy,iz) = w(ix,iy,iz)
+     tplt(ix,iy,iz) = t(ix,iy,1,iz)
+     qplt(ix,iy,iz) = t(ix,iy,2,iz)
+  end do
+  end do
+  end do
+
+  !To fill the halos in the y direction, need to figure out the proc numbers ahead and behind myid
+
+  if ( mod(myid+1,ncpu_s) == 0 ) then  !At max y
+     yfore = mpi_proc_null
+     yback = myid-1
+  elseif (mod(myid,ncpu_s) == 0) then  !At min y
+     yfore = myid+1
+     yback = mpi_proc_null
+  else
+     yfore = myid+1
+     yback = myid-1
+  endif
+
+  nsend = nnx*(kmax-kmin+1)*6
+  nrecv = nsend
+
+  !Send to right, receive from left -- that's all that tecplot needs
+  do iz=kmin,kmax
+  do ix=1,nnx
+     sendbuf(ix,iz,1) = u(ix,iye,iz)
+     sendbuf(ix,iz,2) = v(ix,iye,iz)
+     sendbuf(ix,iz,3) = w(ix,iye,iz)
+     sendbuf(ix,iz,4) = e(ix,iye,iz)
+     sendbuf(ix,iz,5) = t(ix,iye,1,iz)
+     sendbuf(ix,iz,6) = t(ix,iye,2,iz)
+  end do
+  end do
+
+    
+  call mpi_sendrecv(sendbuf(1,kmin,1),nsend,mpi_real8,yfore,0, &
+                    recvbuf(1,kmin,1),nrecv,mpi_real8,yback,0, &
+                    mpi_comm_world,istatus,ierr)
+
+  if (yback .ne. mpi_proc_null) then
+
+  do iz=kmin,kmax
+  do ix=1,nnx
+     uplt(ix,iys-1,iz) = recvbuf(ix,iz,1)
+     vplt(ix,iys-1,iz) = recvbuf(ix,iz,2)
+     wtmp(ix,iys-1,iz) = recvbuf(ix,iz,3)
+     tplt(ix,iys-1,iz) = recvbuf(ix,iz,5)
+     qplt(ix,iys-1,iz) = recvbuf(ix,iz,6)
+  end do
+  end do
+
+  end if
+
+  !Now fill RH:
+  if (iexner .eq. 1) then
+
+  do iz=kmin,kmax
+  do iy=jmin,jmax
+  do ix=1,nnx
+
+     Ttmp = tplt(ix,iy,iz)*(psurf/(psurf-zz(iz)*rhoa*grav))**(-Rd/Cpa)
+     rhplt(ix,iy,iz) = Ttmp*qplt(ix,iy,iz)*Ru/Mw/mod_magnus(Ttmp)*rhoa*100.0
+
+  end do
+  end do
+  end do
+
+  else
+
+  do iz=kmin,kmax
+  do iy=jmin,jmax
+  do ix=1,nnx
+
+     Ttmp = tplt(ix,iy,iz)
+     rhplt(ix,iy,iz) = Ttmp*qplt(ix,iy,iz)*Ru/Mw/mod_magnus(Ttmp)*rhoa*100.0
+
+  end do
+  end do
+  end do
+
+  end if
+
+end subroutine fill_plt_fields
+subroutine fill_plt_part(npsize,xpart,ypart,zpart,upart,vpart,wpart,tpart,rpart)
+  use pars
+  use particles
+  implicit none
+  include 'mpif.h'
+
+  integer :: ip,npsize,nsend,nrecv
+  integer :: procnext,procbefore
+  integer :: ierr,istatus(mpi_status_size)
+  real :: sendbuf(8),recvbuf(8)
+  real*4, intent(inout) :: xpart(npsize),ypart(npsize),zpart(npsize),upart(npsize),vpart(npsize),wpart(npsize),tpart(npsize),rpart(npsize)
+
+  !Proc 0 has no "halo", sends its last one to proc 1, etc.
+  if (myid .eq. 0) then
+     ip = 1
+  else
+     ip = 2
+  end if
+
+  part => first_particle
+  do while (associated(part))
+
+    xpart(ip) = part%xp(1)
+    ypart(ip) = part%xp(2)
+    zpart(ip) = part%xp(3)
+    upart(ip) = part%vp(1)
+    vpart(ip) = part%vp(2)
+    wpart(ip) = part%vp(3)
+    tpart(ip) = part%Tp
+    rpart(ip) = part%radius
+     
+    ip = ip+1
+  part => part%next
+  end do
+
+  !Need to get "halo" of particles by sending to procnext
+  procnext = myid+1
+  procbefore = myid-1
+
+  if (myid==0) then
+     procbefore = mpi_proc_null
+  end if
+  if (myid==numprocs-1) then
+     procnext = mpi_proc_null
+  end if
+
+  sendbuf(1) = xpart(npsize)
+  sendbuf(2) = ypart(npsize)
+  sendbuf(3) = zpart(npsize)
+  sendbuf(4) = upart(npsize)
+  sendbuf(5) = vpart(npsize)
+  sendbuf(6) = wpart(npsize)
+  sendbuf(7) = tpart(npsize)
+  sendbuf(8) = rpart(npsize)
+
+  nsend = 8
+  nrecv = nsend
+   
+  !Send to procnext, receive from procbefore
+  call mpi_sendrecv(sendbuf(1),nsend,mpi_real8,procnext,0, &
+                    recvbuf(1),nrecv,mpi_real8,procbefore,0, &
+                    mpi_comm_world,istatus,ierr)
+
+  if (myid .ne. 0) then
+     xpart(1) = recvbuf(1)
+     ypart(1) = recvbuf(2)
+     zpart(1) = recvbuf(3)
+     upart(1) = recvbuf(4)
+     vpart(1) = recvbuf(5)
+     wpart(1) = recvbuf(6)
+     tpart(1) = recvbuf(7)
+     rpart(1) = recvbuf(8)
+   end if
+   
+
+end subroutine fill_plt_part
+subroutine fill_plt_part_ROOT(nparray,xpart,ypart,zpart,upart,vpart,wpart,tpart,rpart)
+  use pars
+  use particles
+  implicit none
+  include 'mpif.h'
+
+  integer :: i,ip,nparray(numprocs),npsarray(numprocs)
+  integer :: ierr
+  real*4, intent(inout) :: xpart(:),ypart(:),zpart(:),upart(:),vpart(:),wpart(:),tpart(:),rpart(:)
+  real*4, allocatable :: myxpart(:),myypart(:),myzpart(:),myupart(:),myvpart(:),mywpart(:),mytpart(:),myrpart(:)
+
+  allocate(myxpart(numpart),myypart(numpart),myzpart(numpart),myupart(numpart),myvpart(numpart),mywpart(numpart),mytpart(numpart),myrpart(numpart))
+
+  !Everyone collects into "my" arrays
+  ip = 1
+  part => first_particle
+  do while (associated(part))
+
+    myxpart(ip) = part%xp(1)
+    myypart(ip) = part%xp(2)
+    myzpart(ip) = part%xp(3)
+    myupart(ip) = part%vp(1)
+    myvpart(ip) = part%vp(2)
+    mywpart(ip) = part%vp(3)
+    mytpart(ip) = part%Tp
+    myrpart(ip) = part%radius
+
+    ip = ip+1
+  part => part%next
+  end do
+
+!  !Start collecting, starting with root
+!  if (myid .eq. 0) then
+!     xpart(1:numpart) = myxpart(1:numpart)
+!     ypart(1:numpart) = myypart(1:numpart)
+!     zpart(1:numpart) = myzpart(1:numpart)
+!     upart(1:numpart) = myupart(1:numpart)
+!     vpart(1:numpart) = myvpart(1:numpart)
+!     wpart(1:numpart) = mywpart(1:numpart)
+!     tpart(1:numpart) = mytpart(1:numpart)
+!     rpart(1:numpart) = myrpart(1:numpart)
+!  end if
+
+  ip = 1
+  do i=1,numprocs
+
+     if (i==1) then
+        npsarray(i) = 0
+     else
+        npsarray(i) = npsarray(i-1)+nparray(i-1)
+     end if
+
+  end do
+
+  call mpi_gatherv(myxpart,numpart,mpi_real4,xpart,nparray,npsarray,mpi_real4,0,mpi_comm_world,ierr)
+  call mpi_gatherv(myypart,numpart,mpi_real4,ypart,nparray,npsarray,mpi_real4,0,mpi_comm_world,ierr)
+  call mpi_gatherv(myzpart,numpart,mpi_real4,zpart,nparray,npsarray,mpi_real4,0,mpi_comm_world,ierr)
+  call mpi_gatherv(myupart,numpart,mpi_real4,upart,nparray,npsarray,mpi_real4,0,mpi_comm_world,ierr)
+  call mpi_gatherv(myvpart,numpart,mpi_real4,vpart,nparray,npsarray,mpi_real4,0,mpi_comm_world,ierr)
+  call mpi_gatherv(mywpart,numpart,mpi_real4,wpart,nparray,npsarray,mpi_real4,0,mpi_comm_world,ierr)
+  call mpi_gatherv(mytpart,numpart,mpi_real4,tpart,nparray,npsarray,mpi_real4,0,mpi_comm_world,ierr)
+  call mpi_gatherv(myrpart,numpart,mpi_real4,rpart,nparray,npsarray,mpi_real4,0,mpi_comm_world,ierr)
+
+  deallocate(myxpart,myypart,myzpart,myupart,myvpart,mywpart,mytpart,myrpart)
+  
+
+end subroutine fill_plt_part_ROOT
+
+
+end module tec_io


### PR DESCRIPTION
-Added new attribute to the particles (solute volume, vol_s in the code). This is calculated as m_s/rhos
-sr. create_particle: Added an input argument (rho_sol), that takes into account the solute density, to calculate the solute volume.
-sr. lognormal_dist: now takes into account different solute densities to hydrate the particles. This can be done by changing the value of rho_sol in each mode of the CFOG case. Could be used as a blueprint for other cases.
-sr. particle_coalesce: added a mixing rule for solute volume. Also changed the mixing rule of kappa, now uses a solute volume mixing rule instead of solute mass.