### PR TITLE
Gregs cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ case1
 *.suo
 *.json
 *.sqlite
+*.mod
+*.o
+lesmpi.a
+mach.file

--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,8 @@ lesmpi.a: $(OBJS)
 clean:
 	rm -f *.o *.mod lesmpi.a mach.file
 
+# Dependencies between the individual objects.
+les.o: defs.o netcdf_io.o particles.o
+particles.o: defs.o
+netcdf_io.o: particles.o
+tec_io.o: particles.o

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,13 @@ OUTPUTLIB = -L$(NETCDFBASE)/lib
 LINKOPTS  = -lnetcdf -lnetcdff
 
 
-SRC = 	fft.f \
-	kdtree.f90 \
-        defs.F \
-        particles.f90\
-        netcdf_io.f90\
-        tec_io.f90 \
-        les.F
+SRC = defs.F \
+      fft.f \
+      kdtree.f90 \
+      les.F \
+      netcdf_io.f90 \
+      particles.f90 \
+      tec_io.f90
 
 OBJS = $(addsuffix .o, $(basename $(SRC)))
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,34 @@
 FORTRAN=mpif90
 F90=ifort
 
-#FLAGS=-i4 -r8 -O2 -assume byterecl -xHost -fpp
-FLAGS=-i4 -r8 -O2 -assume byterecl -march=core-avx2 -fpp
+# Specify the architecture to optimize for.  Should be one of the following:
+#
+#   host    Optimize for the current system's architecture.  This cannot
+#           be used when running on AMD processors as the resulting executable
+#           will crash with an illegal instruction error.
+#   avx     Optimize for Intel's AVX instruction set.  This is the most advanced
+#           optimization for Intel Ivy Bridge processors and AMD's Bulldozer
+#           processors.
+#   avx2    Optimize for Intel's AVX2 instruction set.  This is the most advanced
+#           optimization for Intel Haswell processors, or newer, and AMD's Epyc
+#           7001, 7002, and 7003 (Zen 1-3) processors.
+#
+# NOTE: Specifying this incorrectly will, at best, result in degraded execution
+#       times and, at worst, result in crashes due to illegal instructions.
+#
+ARCH ?= host
+
+ifeq ($(ARCH), host)
+ARCH_FLAGS = -xHost
+endif
+ifeq ($(ARCH), avx)
+ARCH_FLAGS = -march=corei7-avx
+endif
+ifeq ($(ARCH), avx2)
+ARCH_FLAGS = -march=core-avx2
+endif
+
+FLAGS=-i4 -r8 -O2 -assume byterecl $(ARCH_FLAGS) -fpp
 
 ## UNCOMMENT TO RUN IN DEBUG MODE
 DEBUG_FLAGS=-g -traceback

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,13 @@ SRC = 	fft.f \
         defs.F \
         particles.f90\
         netcdf_io.f90\
-        tec_io.f90
+        tec_io.f90 \
+        les.F
 
 OBJS = $(addsuffix .o, $(basename $(SRC)))
 
 
-lesmpi.a: $(OBJS) les.F
+lesmpi.a: $(OBJS)
 	$(FORTRAN) $^ -o $@  $(FLAGS) $(DEBUG_FLAGS) $(OUTPUTINC) $(OUTPUTLIB) $(LINKOPTS) $(TECLINK) $(TECINCLUDE)
 
 %.o: %.f


### PR DESCRIPTION
Cleanup of the Makefile.  Highlights include:

* Support parallel builds via `make -j`
* Conditional compilation of TecPlot outputs by specifying `make TECPLOT=yes`
* Specify the target architecture to compile for by specifying `make ARCH=<target>` where `<target>` is one of `host`, `avx`, or `avx2`.

I'd recommend using the "Rebase and merge" option when you click the dropdown next to "Merge pull request".  That will keep a linear commit history instead of recording there was a branch involved.