### PR TITLE
David debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ FLAGS=-i4 -r8 -O2 -assume byterecl $(ARCH_FLAGS) -fpp
 
 ## UNCOMMENT TO RUN IN DEBUG MODE
 DEBUG_FLAGS=-g -traceback
-DEBUG_FLAGS+=-check bounds,pointers
+DEBUG_FLAGS+=-check all
 
 # NetCDF output is always enabled.
 OUTPUTINC = -I$(NETCDFBASE)/include

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 FLAGS=-i4 -r8 -O2 -assume byterecl $(ARCH_FLAGS) -fpp
 
 ## UNCOMMENT TO RUN IN DEBUG MODE
-#DEBUG_FLAGS=-g -traceback
+DEBUG_FLAGS=-g -traceback
 #DEBUG_FLAGS+=-check all,noarg_temp_created
 #DEBUG_FLAGS+=-fpe0
 #DEBUG_FLAGS+=-init=arrays -init=snan

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ FLAGS=-i4 -r8 -O2 -assume byterecl $(ARCH_FLAGS) -fpp
 DEBUG_FLAGS=-g -traceback
 DEBUG_FLAGS+=-check all,noarg_temp_created
 DEBUG_FLAGS+=-fpe0
-DEBUG_FLAGS+=-init=arrays -init=snan
+#DEBUG_FLAGS+=-init=arrays -init=snan
+DEBUG_FLAGS+=-init=arrays
 
 # NetCDF output is always enabled.
 OUTPUTINC = -I$(NETCDFBASE)/include

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ FLAGS=-i4 -r8 -O2 -assume byterecl $(ARCH_FLAGS) -fpp
 
 ## UNCOMMENT TO RUN IN DEBUG MODE
 DEBUG_FLAGS=-g -traceback
-#DEBUG_FLAGS+=-check bounds
+DEBUG_FLAGS+=-check bounds,pointers
 
 # NetCDF output is always enabled.
 OUTPUTINC = -I$(NETCDFBASE)/include

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,7 @@ FLAGS=-i4 -r8 -O2 -assume byterecl $(ARCH_FLAGS) -fpp
 DEBUG_FLAGS=-g -traceback
 DEBUG_FLAGS+=-check all,noarg_temp_created
 DEBUG_FLAGS+=-fpe0
-#DEBUG_FLAGS+=-init=arrays -init=snan
-DEBUG_FLAGS+=-init=arrays
+DEBUG_FLAGS+=-init=arrays -init=snan
 
 # NetCDF output is always enabled.
 OUTPUTINC = -I$(NETCDFBASE)/include

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,9 @@ FLAGS=-i4 -r8 -O2 -assume byterecl $(ARCH_FLAGS) -fpp
 
 ## UNCOMMENT TO RUN IN DEBUG MODE
 DEBUG_FLAGS=-g -traceback
-DEBUG_FLAGS+=-check all
+DEBUG_FLAGS+=-check all,noarg_temp_created
+DEBUG_FLAGS+=-fpe0
+DEBUG_FLAGS+=-init=arrays -init=snan
 
 # NetCDF output is always enabled.
 OUTPUTINC = -I$(NETCDFBASE)/include

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ endif
 FLAGS=-i4 -r8 -O2 -assume byterecl $(ARCH_FLAGS) -fpp
 
 ## UNCOMMENT TO RUN IN DEBUG MODE
-DEBUG_FLAGS=-g -traceback
-DEBUG_FLAGS+=-check all,noarg_temp_created
-DEBUG_FLAGS+=-fpe0
-DEBUG_FLAGS+=-init=arrays -init=snan
+#DEBUG_FLAGS=-g -traceback
+#DEBUG_FLAGS+=-check all,noarg_temp_created
+#DEBUG_FLAGS+=-fpe0
+#DEBUG_FLAGS+=-init=arrays -init=snan
 
 # NetCDF output is always enabled.
 OUTPUTINC = -I$(NETCDFBASE)/include

--- a/les.F
+++ b/les.F
@@ -1013,7 +1013,7 @@ c --------------------------- format statements
     1 format(10x,' NNX = ',i5,',  NNY = ',i5,
      + ',  NNZ = ',i5,/,10x,' SFC SMLT = ',i1,
      + ',  FILTER = ',i1,
-     + ',  ITI = ',i6,',  ITMAX = ',i6,/,10x,
+     + ',  ITI = ',i6,',  ITMAX = ',i8,/,10x,
      + ' IUPWIND = ',i1,',  BUYNCY = ',i1,
      + ',  ITCUT = ',i1,/,10x,
      + ' DT = ',e15.6,',  ZO = ',e15.6,',  TS = ',e15.6,

--- a/les.F
+++ b/les.F
@@ -645,13 +645,6 @@ c
       
 
       end if  !ifix_dt .eq. 0
-c
-c -------- for safety if restart set timestep = saved timestep in
-c          restart file
-c
-      if(it_step .eq. iti .and. iti .ne. 0) then
-        dt_new = dt
-      endif
 
 c
       return

--- a/les.F
+++ b/les.F
@@ -7809,6 +7809,7 @@ c          stat(.,3) = Dv*< T' dq'/dz >
          else
            qflucp1 = t(i,j,2,izp1)-txym(izp1,2)
            qflucm1 = t(i,j,2,izm1)-txym(izm1,2)
+           Sqp1 = partHsrc(i,j,izp1)
          end if
          qfluc = t(i,j,2,iz)-txym(iz,2)
          Sq = partHsrc(i,j,iz)

--- a/les.F
+++ b/les.F
@@ -1022,7 +1022,7 @@ c --------------------------- format statements
      + ',  FILTER = ',i1,
      + ',  ITI = ',i6,',  ITMAX = ',i6,/,10x,
      + ' IUPWIND = ',i1,',  BUYNCY = ',i1,
-     + ',  NO ALISNG = ',i1,',  ITCUT = ',i1,/,10x,
+     + ',  ITCUT = ',i1,/,10x,
      + ' DT = ',e15.6,',  ZO = ',e15.6,',  TS = ',e15.6,
      + ',  SUBSD = ',i1,/,
      + 10x,' BRCLICITY = ',i1,',  METHOD = ',i1,',  IOCEAN = ',i1,

--- a/les.F
+++ b/les.F
@@ -2369,7 +2369,6 @@ c
            end do
          end do
 
-
       end if
       end if
 
@@ -5913,58 +5912,6 @@ c
       integer :: ix,iy,iz
       integer :: idum
 
-      !Initialize partcount to 0:
-      partcount = 0.0
-      partcount_t = 0.0
-      vpsum = 0.0
-      vpsum_t = 0.0
-      vpsqrsum = 0.0
-      vpsqrsum_t = 0.0
-      ufsum = 0.0
-      ufsum_t = 0.0
-      ufsqrsum = 0.0
-      ufsqrsum_t = 0.0
-      upwp_t = 0.0
-      upwp_t = 0.0
-      upwp = 0.0
-      Tpsum = 0.0
-      Tpsum_t = 0.0
-      Tpsqrsum = 0.0
-      Tpsqrsum_t = 0.0
-      Tfsum = 0.0
-      Tfsum_t = 0.0
-      qfsum = 0.0
-      qfsum_t = 0.0
-      wpTpsum = 0.0
-      wpTpsum_t = 0.0
-      partsrc = 0.0
-      partsrc_t = 0.0
-      partTsrc = 0.0
-      partTsrc_t = 0.0
-      partHsrc = 0.0
-      partHsrc_t = 0.0
-      partTEsrc = 0.0
-      partTEsrc_t = 0.0
-      radsum = 0.0 
-      radsum_t = 0.0 
-      rad2sum = 0.0 
-      rad2sum_t = 0.0 
-      multcount = 0.0
-      multcount_t = 0.0
-      mwsum = 0.0
-      mwsum_t = 0.0
-      qstarsum = 0.0
-      qstarsum_t = 0.0 
-      u = 0.0
-      v = 0.0
-      w = 0.0
-      e = 0.0
-      t = 0.0
-      r1 = 0.0
-      r2 = 0.0
-      r3 = 0.0
-      r4 = 0.0
-      r5 = 0.0
 
 c ------------ note set nmatch in sr. iso so that
 c              it is compatible with conditions here
@@ -8435,6 +8382,16 @@ c
      +         r3(nnx,iys:iye,izs-1:ize+1),
      +         r4(nnx,iys:iye,nscl,izs-1:ize+1),
      +         r5(nnx,iys:iye,izs-1:ize+1))
+      u = 0.0
+      v = 0.0
+      w = 0.0
+      t = 0.0
+      e = 0.0
+      r1 = 0.0
+      r2 = 0.0
+      r3 = 0.0
+      r4 = 0.0
+      r5 = 0.0
 
 c   ------Allocate arrays for SFS stress and its derivatives
       allocate(sigm_s(nnxp2,iys:iye,izs-1:ize+1),
@@ -8477,46 +8434,87 @@ c
       T2_t = 0.0
 
       allocate(partcount(nnx,iys:iye,izs-1:ize+1))
+      partcount = 0.0
       allocate(partcount_t(0:nnz+1,iys:iye,mxs:mxe))
+      partcount_t = 0.0
       allocate(upwp_t(0:nnz+1,iys:iye,mxs:mxe))
+      upwp_t = 0.0
       allocate(upwp(nnx,iys:iye,izs-1:ize+1))
+      upwp = 0.0
       allocate(vpsum(nnx,iys:iye,izs-1:ize+1,1:3))
+      vpsum = 0.0
       allocate(vpsum_t(0:nnz+1,iys:iye,mxs:mxe,1:3))
+      vpsum_t = 0.0
       allocate(vpsqrsum(nnx,iys:iye,izs-1:ize+1,1:3))
+      vpsqrsum = 0.0
       allocate(vpsqrsum_t(0:nnz+1,iys:iye,mxs:mxe,1:3))
+      vpsqrsum_t = 0.0
       allocate(ufsum(nnx,iys:iye,izs-1:ize+1,1:3))
+      ufsum = 0.0
       allocate(ufsum_t(0:nnz+1,iys:iye,mxs:mxe,1:3))
+      ufsum_t = 0.0
       allocate(ufsqrsum(nnx,iys:iye,izs-1:ize+1,1:3))
+      ufsqrsum = 0.0
       allocate(ufsqrsum_t(0:nnz+1,iys:iye,mxs:mxe,1:3))
+      ufsqrsum_t = 0.0
       allocate(Tpsum(nnx,iys:iye,izs-1:ize+1))
+      Tpsum = 0.0
       allocate(Tpsum_t(0:nnz+1,iys:iye,mxs:mxe))
+      Tpsum_t = 0.0
       allocate(Tpsqrsum(nnx,iys:iye,izs-1:ize+1))
+      Tpsqrsum = 0.0
       allocate(Tpsqrsum_t(0:nnz+1,iys:iye,mxs:mxe))
+      Tpsqrsum_t = 0.0
       allocate(Tfsum(nnx,iys:iye,izs-1:ize+1))
+      Tfsum = 0.0
       allocate(Tfsum_t(0:nnz+1,iys:iye,mxs:mxe))
+      Tfsum_t = 0.0
       allocate(qfsum(nnx,iys:iye,izs-1:ize+1))
+      qfsum = 0.0
       allocate(qfsum_t(0:nnz+1,iys:iye,mxs:mxe))
+      qfsum_t = 0.0
       allocate(wpTpsum(nnx,iys:iye,izs-1:ize+1))
+      wpTpsum = 0.0
       allocate(wpTpsum_t(0:nnz+1,iys:iye,mxs:mxe))
+      wpTpsum_t = 0.0
       allocate(partsrc(nnx,iys:iye,izs-1:ize+1,1:3))
+      partsrc = 0.0
       allocate(partsrc_t(0:nnz+1,iys:iye+1,mxs:mxe+1,1:3))
+      partsrc_t = 0.0
       allocate(partTsrc(nnx,iys:iye,izs-1:ize+1))
+      partTsrc = 0.0
       allocate(partTsrc_t(0:nnz+1,iys:iye+1,mxs:mxe+1))
+      partTsrc_t = 0.0
       allocate(radsum(nnx,iys:iye,izs-1:ize+1))
+      radsum = 0.0
       allocate(radsum_t(0:nnz+1,iys:iye,mxs:mxe)) 
+      radsum_t = 0.0
       allocate(rad2sum(nnx,iys:iye,izs-1:ize+1)) 
+      rad2sum = 0.0
       allocate(rad2sum_t(0:nnz+1,iys:iye,mxs:mxe))
+      rad2sum_t = 0.0
       allocate(multcount(nnx,iys:iye,izs-1:ize+1)) 
+      multcount = 0.0
       allocate(multcount_t(0:nnz+1,iys:iye,mxs:mxe)) 
+      multcount_t = 0.0
       allocate(mwsum(nnx,iys:iye,izs-1:ize+1)) 
+      mwsum = 0.0
       allocate(mwsum_t(0:nnz+1,iys:iye,mxs:mxe)) 
+      mwsum_t = 0.0
       allocate(partHsrc(nnx,iys:iye,izs-1:ize+1))
+      partHsrc = 0.0
       allocate(partHsrc_t(0:nnz+1,iys:iye+1,mxs:mxe+1))
+      partHsrc_t = 0.0
       allocate(partTEsrc(nnx,iys:iye,izs-1:ize+1))
+      partTEsrc = 0.0
       allocate(partTEsrc_t(0:nnz+1,iys:iye+1,mxs:mxe+1))
+      partTEsrc_t = 0.0
       allocate(qstarsum(nnx,iys:iye,izs-1:ize+1)) 
+      qstarsum = 0.0
       allocate(qstarsum_t(0:nnz+1,iys:iye,mxs:mxe)) 
+      qstarsum_t = 0.0
 
+      radsrc = 0.0
 
 c ------------- allocate space for boundary condition arrays
 c               on top and bottom of domain

--- a/les.F
+++ b/les.F
@@ -4883,9 +4883,11 @@ c
       do iscl=1,nscl
          t1xy(iscl) = buf(3+iscl)*fnxy
       enddo
+
       vsfc  = sqrt(u1xy*u1xy+v1xy*v1xy)
       windm = amax1(windm,ufree)
       vsfc  = amax1(vsfc,ufree)
+
 c
 c ---------- limits for zeta
 c
@@ -4969,13 +4971,15 @@ c
 c
 c ------- surface details, for debug
 c
-!      write(nprt,2000) windm, utau, qstar(1), tsfcc(1), amonin, zeta,
+!      if (myid.eq.0) then
+!      write(*,2000) windm, utau, qstar(1), tsfcc(1), amonin, zeta,
 !     +              z1, batag, vk, batagk, zo, zos
- 2000 format(' 2000 suft ',/,
-     +       '    windm = ',e15.6,' utau = ',e15.6,' qstar = ',e15.6,/,
-     +       '    tsfcc = ',e15.6,' MO L = ',e15.6,' z1/L = ',e15.6,/,
-     +       '    z1 = ',e15.6,' batag = ',e15.6,' vk = ',e15.6,/,
-     +       '    batagk = ',e15.6,' zo = ',e15.6,' zos = ',e15.6)
+! 2000 format(' 2000 suft ',/,
+!     +       '    windm = ',e15.6,' utau = ',e15.6,' qstar = ',e15.6,/,
+!     +       '    tsfcc = ',e15.6,' MO L = ',e15.6,' z1/L = ',e15.6,/,
+!     +       '    z1 = ',e15.6,' batag = ',e15.6,' vk = ',e15.6,/,
+!     +       '    batagk = ',e15.6,' zo = ',e15.6,' zos = ',e15.6)
+!      end if
 c
       if (utau.gt.10.0) then
          write(6,9000)
@@ -5881,13 +5885,24 @@ c
       use con_data
       use con_stats
       use particles
-      real psi(nnx,iys:iye), psix(nnx,iys:iye),
+      implicit none
+ 
+      real ::  psi(nnx,iys:iye), psix(nnx,iys:iye),
      +     psiy(nnx,iys:iye,izs:izs), uxx(nnx,iys:iye),
      +     vyy(nnx,iys:iye,izs:izs),Ttmp
 
-      real :: slope_q,slope_t
-      real :: z_switch,t_switch,q_switch
-      real :: t_surf,q_surf
+      real :: ampv,ampt,sum_psi,vmaxx,vmag,facv,ran1
+
+      real :: slope_q,slope_t,slope_u
+      real :: slope_t1,slope_t2,slope_u1,slope_v1
+      real :: z_switch,t_switch,q_switch,u_switch,v_switch
+      real :: z_switch_q,z_switch_t,z_switch_v,z_switch_u
+      real :: t_surf,q_surf,u_surf,v_surf
+      real :: t_temp,q_temp,u_temp
+      real :: q_top,t_top,u_top,v_top,slope_q1,slope_q2
+
+      integer :: ix,iy,iz
+      integer :: idum
 
       !Initialize partcount to 0:
       partcount = 0.0

--- a/les.F
+++ b/les.F
@@ -4826,9 +4826,20 @@ c
       use con_data
       use con_stats
       use particles
-      real buf(3+nscl)
-c
-      parameter (iter_mo = 30, zeta_min = -6.0, zeta_max = 3.0)
+      implicit none
+
+      real, parameter :: zeta_min=-6.0, zeta_max=3.0
+      integer, parameter :: iter_mo = 30
+ 
+      integer :: iz,izp1,izm1,ix,iy,iscl,iter,ierr
+      integer, intent(in) :: it
+      real ::  buf(3+nscl)
+      real :: ufree,tol,vsfc,utau2
+      real :: zeta,zeta_mn,zeta_mx,zeta_a
+      real :: f_con,f_new,d_theta,u_fac
+      real :: phim,phis,psim,psis,t_fac
+      real :: dnom,tep,thta
+      real :: mod_magnus
 
 
 c
@@ -5000,7 +5011,7 @@ c
 
           dnom = zosdy*vk74in
           tsfcc(2)=surf_RH/100.0*
-     +    Mw/Ru/tsfcc(1)*mod_Magnus(tsfcc(1))/rhoa
+     +    Mw/Ru/tsfcc(1)*mod_magnus(tsfcc(1))/rhoa
             thstar(iscl) = (t1xy(iscl) - tsfcc(iscl))/dnom
             t10xy(iscl)  = thstar(iscl)*dnom
             qstar(iscl)  = -utau*thstar(iscl)
@@ -5015,7 +5026,7 @@ c
             !Humidity is a Dirichlet condition at surf_RH
             !Based on temperature in tsfcc(1)
             tsfcc(2)=surf_RH/100.0*
-     +      Mw/Ru/tsfcc(1)*mod_Magnus(tsfcc(1))/rhoa
+     +      Mw/Ru/tsfcc(1)*mod_magnus(tsfcc(1))/rhoa
 
             thstar(iscl) = (t1xy(iscl) - tsfcc(iscl))/dnom
             t10xy(iscl)  = thstar(iscl)*dnom
@@ -5432,10 +5443,15 @@ c
          dtdzf(1)=(311.85-308.2)/(3000.0-2000.0)
          dtdzf(2)=(3.0e-3-4.2e-3)/(3000.0-2000.0)
 
-         elseif (icase.eq.3) then !CFOG
+         elseif (icase.eq.3) then !C-FOG
 
          dtdzf(1)=(285.5-284.0)/(80.0-30.0)
          dtdzf(2)=(0.006-0.00805)/(80.0-30.0)         
+
+         elseif (icase.eq.6) then !FATIMA
+
+         dtdzf(1)=(289.5-287.51)/(128.0-70.0)
+         dtdzf(2)=(0.0094-0.0098)/(128.0-70.0)
 
          end if
 
@@ -6187,7 +6203,7 @@ c
 
          !Make a constant q profile at RH based on surface temp:
 !            t(ix,iy,2,iz) = surf_RH/100.0*
-!     +      Mw/Ru/t_lower*mod_Magnus(t_lower)/rhoa
+!     +      Mw/Ru/t_lower*mod_magnus(t_lower)/rhoa
 
          !Make a desired profile of RH:
 !            !Convert theta to temperature:
@@ -6196,7 +6212,7 @@ c
 !
 !            !Get temperature based on desired RH
 !            t(ix,iy,2,iz) = surf_RH/100.0*
-!     +      Mw/Ru/Ttmp*mod_Magnus(Ttmp)/rhoa
+!     +      Mw/Ru/Ttmp*mod_magnus(Ttmp)/rhoa
 
 
             w(ix,iy,iz)   = 0.
@@ -7249,14 +7265,20 @@ c
       use con_data
       use con_stats
       use particles
+      implicit none
 c
 c ------- indices for indexing array stat(.,.)
 c         js = number of non-scalar stats
 c         ns = number of scalar stats
 c
-      parameter(js = 43, ns = 5, nstat = js + ns*nscl)
-      real stat(1:nnz,nstat)
-      real RHtmp, Ttmp
+      integer, parameter :: js = 43, ns = 5, nstat = js + ns*nscl
+      real :: stat(1:nnz,nstat)
+
+      integer :: ix,iy,iz,izm1,izp1,izp2,m1,m2,m3,m4,m5,i,l
+
+      real :: sgn
+      real :: rlim
+      real ::  RHtmp, Ttmp, mod_magnus
 c
 c -------- stat(.,1) = u*u = ups
 c          stat(.,2) = v*v = vps
@@ -7389,6 +7411,7 @@ c
 
          RHtmp = Ttmp*
      +   t(ix,iy,2,iz)*Ru/Mw/mod_magnus(Ttmp)*rhoa*100.0
+
          stat(iz,35) = stat(iz,35) + RHtmp
          stat(iz,36) = stat(iz,36) + Ttmp
          stat(iz,37) = stat(iz,37) + RHtmp**2
@@ -10599,7 +10622,7 @@ c
       use pars
       use con_data
       implicit none
-      real :: RHB,RHT,mod_Magnus
+      real :: RHB,RHT,mod_magnus
 
       !Assuming tsfcc(2),Ttop(2),Tbot(2) in params.in are giving RH:
       if (iDNS .eq. 1) then
@@ -10608,8 +10631,8 @@ c
          RHB = Tbot(2)
 
          !Convert RH given in input file into specific humidity
-         Ttop(2) = RHT/100.0*Mw/Ru/Ttop(1)*mod_Magnus(Ttop(1))/rhoa
-         Tbot(2) = RHB/100.0*Mw/Ru/Tbot(1)*mod_Magnus(Tbot(1))/rhoa
+         Ttop(2) = RHT/100.0*Mw/Ru/Ttop(1)*mod_magnus(Ttop(1))/rhoa
+         Tbot(2) = RHB/100.0*Mw/Ru/Tbot(1)*mod_magnus(Tbot(1))/rhoa
 
          if (myid==0) then
            write(*,*) 'SURFACE HUMIDITY: %RH, q = ',RHB,Tbot(2)
@@ -10619,7 +10642,7 @@ c
 
          RHB = tsfcc(2)
 
-         tsfcc(2) = RHB/100.0*Mw/Ru/tsfcc(1)*mod_Magnus(tsfcc(1))/rhoa
+         tsfcc(2) = RHB/100.0*Mw/Ru/tsfcc(1)*mod_magnus(tsfcc(1))/rhoa
 
          if (myid==0) then
            write(*,*) 'SURFACE HUMIDITY: %RH, q = ',RHB,tsfcc(2)
@@ -10693,17 +10716,17 @@ c
 
 
       end subroutine read_input_file
-      function mod_Magnus(T)
+      function mod_magnus(T)
       implicit none
 
       !Take in T in Kelvin and return saturation vapor pressure using function of Alduchov and Eskridge, 1996
       real,intent(in) :: T
-      real :: mod_Magnus
+      real :: mod_magnus
 
-      mod_Magnus = 610.94 *exp((17.6257*(T-273.15))/(243.04+(T-273.15)))
+      mod_magnus = 610.94 *exp((17.6257*(T-273.15))/(243.04+(T-273.15)))
 
 
-      end function mod_Magnus
+      end function mod_magnus
  
       function ran2(idum)
       integer :: idum,IM1,IM2,IMM1,IA1,IA2,IQ1,IQ2,IR1,IR2,NTAB,NDIV

--- a/les.F
+++ b/les.F
@@ -7192,7 +7192,7 @@ c
      + 'SGS_WT',7X,'SHRZ',8X,'BUOY')
       do 19999 iz=iz_end,iz_strt,-1
          !write(lu,4300)iz,txym(iz,1)-t_ref,divz(iz),
-	 write(lu,4300)iz,txym(iz,1)-tref, txym(iz,2),divz(iz),
+	 write(lu,4300)iz,txym(iz,1)-t_ref, txym(iz,2),divz(iz),
      +              englez(iz),eavg(iz),wtle(iz,1),
      +              wtsb(iz,1),shrz(iz),buyz(iz)
  4300    format(1X,I3,e12.4,8e12.4)

--- a/les.F
+++ b/les.F
@@ -8435,12 +8435,23 @@ c
      +         wext(0:nnz+1,iys-2:iye+3,mxs-2:mxe+3),
      +         Text(0:nnz+1,iys-2:iye+3,mxs-2:mxe+3),
      +         T2ext(0:nnz+1,iys-2:iye+3,mxs-2:mxe+3)) 
+      uext = 0.0
+      vext = 0.0
+      wext = 0.0
+      Text = 0.0
+      T2ext = 0.0
+
       !Transposed velocities to do the uf interpolation:
       allocate(u_t(0:nnz+1,iys:iye,mxs:mxe),
      +         v_t(0:nnz+1,iys:iye,mxs:mxe),
      +         w_t(0:nnz+1,iys:iye,mxs:mxe), 
      +         T_t(0:nnz+1,iys:iye,mxs:mxe),
      +         T2_t(0:nnz+1,iys:iye,mxs:mxe))
+      u_t = 0.0
+      v_t = 0.0
+      w_t = 0.0
+      T_t = 0.0
+      T2_t = 0.0
 
       allocate(partcount(nnx,iys:iye,izs-1:ize+1))
       allocate(partcount_t(0:nnz+1,iys:iye,mxs:mxe))
@@ -8516,6 +8527,8 @@ c ------------- allocate space for pressure, pressure bcs
 c
       allocate(p(nnxp2,iys:iye,izs-1:ize+1),
      +         ptop(nnxp2,iys:iye,2))
+      p = 0.0
+      ptop = 0.0
 c
 c ------------- allocate space for viscosity and diffusivity
 c

--- a/les.F
+++ b/les.F
@@ -623,7 +623,7 @@ c
       tauc = 5.0
       do iz=1,nnz
          
-         tauc_tmp = 1.0/(pi2*Dv*2.0*radmean(iz)*Nc(iz)+1.0e-12)
+         tauc_tmp = 1.0/(pi2*Dv*2.0*radmean(iz)*Nc(iz)+1.0e-10)
 
 
          if (.not. isnan(tauc_tmp)) then
@@ -7517,7 +7517,7 @@ c
          vp3msqr(iz) = stat(iz,17)/stat(iz,11)-vp3mean(iz)**2
          upwpm(iz) = stat(iz,21)/stat(iz,11)-(vp1mean(iz)*vp3mean(iz))
          Tpmean(iz) = stat(iz,22)/stat(iz,11)
-         Tpmsqr(iz) = sqrt(stat(iz,23)/stat(iz,11)-Tpmean(iz)**2)
+         Tpmsqr(iz) = stat(iz,23)/stat(iz,11)-Tpmean(iz)**2
          Tfmean(iz) = stat(iz,24)/stat(iz,11)
          qfmean(iz) = stat(iz,25)/stat(iz,11)
          wpTpm(iz) = stat(iz,26)/stat(iz,11)-(Tpmean(iz)*vp3mean(iz))

--- a/les.F
+++ b/les.F
@@ -623,7 +623,7 @@ c
       tauc = 5.0
       do iz=1,nnz
          
-         tauc_tmp = 1.0/(pi2*Dv*2.0*radmean(iz)*Nc(iz))
+         tauc_tmp = 1.0/(pi2*Dv*2.0*radmean(iz)*Nc(iz)+1.0e-12)
 
 
          if (.not. isnan(tauc_tmp)) then
@@ -7481,47 +7481,74 @@ c
       eavg(iz)   = stat(iz,8)*fnxy
       uwle(iz)   = stat(iz,9)*fnxy
       vwle(iz)   = stat(iz,10)*fnxy
-      zconc(iz)  = stat(iz,11)/xl/yl/dzw(iz)
-      vp1mean(iz) = stat(iz,12)/stat(iz,11)
-      vp2mean(iz) = stat(iz,13)/stat(iz,11)
-      vp3mean(iz) = stat(iz,14)/stat(iz,11)
-      vp1msqr(iz) = stat(iz,15)/stat(iz,11)-vp1mean(iz)**2
-      vp2msqr(iz) = stat(iz,16)/stat(iz,11)-vp2mean(iz)**2
-      vp3msqr(iz) = stat(iz,17)/stat(iz,11)-vp3mean(iz)**2
+
+      if (stat(iz,11).eq.0) then
+         zconc(iz) = 0.0
+         vp1mean(iz) = 0.0
+         vp2mean(iz) = 0.0
+         vp3mean(iz) = 0.0
+         vp1msqr(iz) = 0.0
+         vp2msqr(iz) = 0.0
+         vp3msqr(iz) = 0.0
+         upwpm(iz) = 0.0
+         Tpmean(iz) = 0.0
+         Tpmsqr(iz) = 0.0
+         Tfmean(iz) = 0.0
+         qfmean(iz) = 0.0
+         wpTpm(iz) = 0.0
+         radmean(iz) = 0.0
+         rad2mean(iz) = 0.0
+         multmean(iz) = 0.0
+         mwmean(iz) = 0.0
+         qstarm(iz) = 0.0
+         uf1mean(iz) = 0.0
+         uf2mean(iz) = 0.0
+         uf3mean(iz) = 0.0
+         uf1msqr(iz) = 0.0
+         uf2msqr(iz) = 0.0
+         uf3msqr(iz) = 0.0
+      else
+         zconc(iz)  = stat(iz,11)/xl/yl/dzw(iz)
+         vp1mean(iz) = stat(iz,12)/stat(iz,11)
+         vp2mean(iz) = stat(iz,13)/stat(iz,11)
+         vp3mean(iz) = stat(iz,14)/stat(iz,11)
+         vp1msqr(iz) = stat(iz,15)/stat(iz,11)-vp1mean(iz)**2
+         vp2msqr(iz) = stat(iz,16)/stat(iz,11)-vp2mean(iz)**2
+         vp3msqr(iz) = stat(iz,17)/stat(iz,11)-vp3mean(iz)**2
+         upwpm(iz) = stat(iz,21)/stat(iz,11)-(vp1mean(iz)*vp3mean(iz))
+         Tpmean(iz) = stat(iz,22)/stat(iz,11)
+         Tpmsqr(iz) = sqrt(stat(iz,23)/stat(iz,11)-Tpmean(iz)**2)
+         Tfmean(iz) = stat(iz,24)/stat(iz,11)
+         qfmean(iz) = stat(iz,25)/stat(iz,11)
+         wpTpm(iz) = stat(iz,26)/stat(iz,11)-(Tpmean(iz)*vp3mean(iz))
+         radmean(iz) = stat(iz,28)/stat(iz,11) 
+         rad2mean(iz)= stat(iz,29)/stat(iz,11)
+         multmean(iz) = stat(iz,30)/stat(iz,11)
+         mwmean(iz) = stat(iz,31)/stat(iz,11)
+         qstarm(iz) = stat(iz,34)/stat(iz,11)
+         uf1mean(iz) = stat(iz,38)/stat(iz,11)
+         uf2mean(iz) = stat(iz,39)/stat(iz,11)
+         uf3mean(iz) = stat(iz,40)/stat(iz,11)
+         uf1msqr(iz) = stat(iz,41)/stat(iz,11)-uf1mean(iz)**2
+         uf2msqr(iz) = stat(iz,42)/stat(iz,11)-uf2mean(iz)**2
+         uf3msqr(iz) = stat(iz,43)/stat(iz,11)-uf3mean(iz)**2
+      end if
+         
+         
       m1src(iz) = stat(iz,18)*fnxy
       m2src(iz) = stat(iz,19)*fnxy
       m3src(iz) = stat(iz,20)*fnxy
       uw_tot(iz) = uwle(iz) + uwsb(iz)
       vw_tot(iz) = vwle(iz) + vwsb(iz)
-      upwpm(iz) = stat(iz,21)/stat(iz,11)-(vp1mean(iz)*vp3mean(iz))
-      Tpmean(iz) = stat(iz,22)/stat(iz,11)
-      Tpmsqr(iz) = sqrt(stat(iz,23)/stat(iz,11)-Tpmean(iz)**2)
-      Tfmean(iz) = stat(iz,24)/stat(iz,11)
-      qfmean(iz) = stat(iz,25)/stat(iz,11)
-      wpTpm(iz) = stat(iz,26)/stat(iz,11)-(Tpmean(iz)*vp3mean(iz))
       Tpsrc(iz) = stat(iz,27)*fnxy
-      radmean(iz) = stat(iz,28)/stat(iz,11) 
-      rad2mean(iz)= stat(iz,29)/stat(iz,11)
- 
-      multmean(iz) = stat(iz,30)/stat(iz,11)
-      mwmean(iz) = stat(iz,31)/stat(iz,11)
       Nc(iz) = stat(iz,30)/xl/yl/dzw(iz)
       ql(iz) = stat(iz,31)/xl/yl/dzw(iz)/rhoa
- 
       Hpsrc(iz) = stat(iz,32)*fnxy
       TEpsrc(iz) = stat(iz,33)*fnxy
-      qstarm(iz) = stat(iz,34)/stat(iz,11)
-
       RHxym(iz) = stat(iz,35)*fnxy
       tempxym(iz) = stat(iz,36)*fnxy
       RHmsqr(iz) = stat(iz,37)*fnxy
 
-      uf1mean(iz) = stat(iz,38)/stat(iz,11)
-      uf2mean(iz) = stat(iz,39)/stat(iz,11)
-      uf3mean(iz) = stat(iz,40)/stat(iz,11)
-      uf1msqr(iz) = stat(iz,41)/stat(iz,11)-uf1mean(iz)**2
-      uf2msqr(iz) = stat(iz,42)/stat(iz,11)-uf2mean(iz)**2
-      uf3msqr(iz) = stat(iz,43)/stat(iz,11)-uf3mean(iz)**2
 
       !Doesn't need averaging if basing radiation source on average ql:
       radtend(iz) = radsrc(iz)

--- a/netcdf_io.f90
+++ b/netcdf_io.f90
@@ -1099,7 +1099,7 @@ subroutine fill_yz_slice(yzslice,dat,tmp)
       integer :: yzslice
       real,intent(in) :: dat(1:nnx,iys:iye,izs:ize)
       real,intent(out) :: tmp(nny,nnz)
-      integer :: ierr,ip,mynx,myny,mynz,iystmp,iyetmp,izstmp,izetmp,istatus
+      integer :: ierr,ip,mynx,myny,mynz,iystmp,iyetmp,izstmp,izetmp,istatus(MPI_STATUS_SIZE)
       integer :: sbuf_limits(4),rbuf_limits(4)
       real,allocatable :: sbuf_data(:,:),rbuf_data(:,:)
 
@@ -1167,7 +1167,7 @@ subroutine fill_xy_slice(xyslice,dat,tmp)
       integer :: xyslice
       real,intent(in) :: dat(1:nnx,iys:iye,izs:ize)
       real,intent(out) :: tmp(nnx,nny)
-      integer :: ierr,ip,mynx,myny,mynz,iystmp,iyetmp,izstmp,izetmp,istatus
+      integer :: ierr,ip,mynx,myny,mynz,iystmp,iyetmp,izstmp,izetmp,istatus(MPI_STATUS_SIZE)
       integer :: sbuf_limits(4),rbuf_limits(4)
       real,allocatable :: sbuf_data(:,:),rbuf_data(:,:)
 
@@ -1249,7 +1249,7 @@ subroutine fill_xz_slice(xzslice,dat,tmp)
       integer :: xzslice
       real,intent(in) :: dat(1:nnx,iys:iye,izs:ize)
       real,intent(out) :: tmp(nnx,nnz)
-      integer :: ierr,ip,mynx,myny,mynz,iystmp,iyetmp,izstmp,izetmp,istatus
+      integer :: ierr,ip,mynx,myny,mynz,iystmp,iyetmp,izstmp,izetmp,istatus(MPI_STATUS_SIZE)
       integer :: sbuf_limits(4),rbuf_limits(4)
       real,allocatable :: sbuf_data(:,:),rbuf_data(:,:)
 

--- a/particles.f90
+++ b/particles.f90
@@ -1765,7 +1765,7 @@ CONTAINS
 
       mult_a = mult_init*(1+4.8081e-04*mult_factor)/(1+4.8081e-04)
 
-      mult_c = mult_init*(1+4.8081e-04*mult_factor)/(mult_factor*(1+4.8081e-04))      
+      mult_c = mult_init*(1+4.8081e-04*mult_factor)/(mult_factor*(1+4.8081e-04))
 
 
       !set_binsdata does logarithmic binning!
@@ -2049,6 +2049,7 @@ CONTAINS
 
       my_reintro = 0
       tot_reintro = 0
+      it_delay=1
 
       end if
 
@@ -2280,6 +2281,7 @@ CONTAINS
       xv = ran2(iseed)*(xmax-xmin) + xmin
       yv = ran2(iseed)*(ymax-ymin) + ymin
       zv = ran2(iseed)*(zi-zw1) + zw1
+      
       xp_init = (/xv,yv,zv/)
 
 
@@ -2650,6 +2652,8 @@ CONTAINS
             call lognormal_dist(rad_init,m_s,kappa_s,M,S)
 
             call create_particle(xp_init,vp_init,Tp_init,m_s,kappa_s,mult,rad_init,idx_old,procidx_old)
+
+            write(*,'(a8,10e15.6,3i)') 'DHR7:',xp_init,vp_init,Tp_init,m_s,kappa_s,rad_init,idx_old,procidx_old,mult
 
        else
 
@@ -4098,6 +4102,8 @@ CONTAINS
                 correct = matmul(finalJ,fv1)
                 vec2 = v1 - correct
 
+                counts = 0
+                relax = 1.0
                 do while ((vec2(1)<0) .OR. (vec2(2)<0) .OR. isnan(vec2(1)))
                         counts = counts + 1
                         coeff = 0.5
@@ -4116,9 +4122,6 @@ CONTAINS
                 if (sqrt(dot_product(correct,correct))<error) then
                         EXIT
                 end if
-
-                relax = 1.0
-                counts = 0
 
                 v1 = vec2
 
@@ -4461,12 +4464,25 @@ CONTAINS
      ! TKE : resolved + Subgrid at grid center
       !---------------------------------
 !      tot_eng = (engsbz(iz_part+1) + engz(iz_part+1))
-     englez_bar = 0.5*(englez(iz_part)+englez(iz_part+1))
+     if (iz_part.eq.0) then
+        englez_bar = 0.5*englez(iz_part+1)
+     elseif (iz_part.eq.nnz) then
+        englez_bar = 0.5*englez(iz_part)
+     else
+        englez_bar = 0.5*(englez(iz_part)+englez(iz_part+1))
+     endif
      engsbz_bar = 0.5*(engsbz(iz_part)+engsbz(iz_part+1))
      tengz = englez_bar + engsbz_bar
     !---------------------------------
     ! Calculate fs basd on w-componet of velocity
-     sigm_w = 0.5*(wps(iz_part)+wps(iz_part+1))
+     if (iz_part.eq.0) then
+        sigm_w = 0.5*(wps(iz_part+1))
+     elseif (iz_part.eq.nnz) then
+        sigm_w = 0.5*(wps(iz_part))
+     else
+        sigm_w = 0.5*(wps(iz_part)+wps(iz_part+1))
+     endif
+
      sigm_ws = 0.5*(engsbz(iz_part)+engsbz(iz_part+1))/3.0
 
 !     ---------write for single droplet ---------

--- a/particles.f90
+++ b/particles.f90
@@ -1184,8 +1184,7 @@ CONTAINS
      if (iy .lt. iys) write(*,*) 'proc',myid,'has iy = ',iy
      if (iz .gt. nnz+1) write(*,*) 'proc',myid,'has iz = ',iz
      if (iz .lt. 0) then
-         write(*,*) 'proc',myid,'has iz = ',iz
-         write(*,*) 'DHR:',part%radius,part%xp(3),part%mult,part%vp(3)
+         write(*,*) 'proc',myid,'has iz = ',iz,part%radius,part%xp(3),part%mult,part%vp(3)
      end if
 
      !Recall to subtract g since momentum is extracted form
@@ -3202,11 +3201,11 @@ CONTAINS
         end if
 
         if (part%qinf .lt. 0.0) then
-          !write(*,'(a30,2i,12e15.6)') 'WARNING: NEG QINF',  &
-          !part%pidx,part%procidx, &
-          !part%radius,part%qinf,part%Tp,part%Tf,part%xp(3), &
-          !part%kappa_s,part%m_s,part%vp(1),part%vp(2),part%vp(3), &
-          !part%res,part%sigm_s
+          write(*,'(a30,2i,12e15.6)') 'WARNING: NEG QINF',  &
+          part%pidx,part%procidx, &
+          part%radius,part%qinf,part%Tp,part%Tf,part%xp(3), &
+          part%kappa_s,part%m_s,part%vp(1),part%vp(2),part%vp(3), &
+          part%res,part%sigm_s
         end if
 
 
@@ -4372,12 +4371,6 @@ CONTAINS
 
       mflag = 0
       esa = mod_Magnus(part%Tf)
-
-      !write(*,'(a8,5e15.6)') 'DHR3:',2*Mw*Gam,Ru*rhow*part%Tf,(Ru*part%Tf*rhoa*part%qinf),Mw*esa,(Ru*part%Tf*rhoa*part%qinf)/(Mw*esa)
-
-      if ((Ru*part%Tf*rhoa*part%qinf)/(Mw*esa) .lt. 0.0) then
-      write(*,*) 'DHR3:',Ru,part%Tf,rhoa,part%qinf,Mw,esa
-      endif
 
       a = -(2*Mw*Gam)/(Ru*rhow*part%Tf)/LOG((Ru*part%Tf*rhoa*part%qinf)/(Mw*esa))
       c = (part%kappa_s*part%m_s)/((2.0/3.0)*pi2*rhos)/LOG((Ru*part%Tf*rhoa*part%qinf)/(Mw*esa))

--- a/particles.f90
+++ b/particles.f90
@@ -776,7 +776,7 @@ CONTAINS
    
   integer :: ix,iy,izuv,izw,iz,i,k,j
   integer :: ipt,jpt,kpt,kwpt
-  real :: wtx,wty,wtz,wtzw,wtt,wttw
+  real :: wtx,wty,wtz,wtzw,wtt
   real :: xv,yv,zv,zwv
   
 
@@ -790,8 +790,13 @@ CONTAINS
   kpt = minloc(zz,1,mask=(zz.gt.part%xp(3))) - 2
   kwpt = minloc(z,1,mask=(z.gt.part%xp(3))) - 2
 
+  wtx=0.0
+  wty=0.0
+  wtz=0.0
+  wtzw=0.0
+  wtt=0.0
 
-  part%uf(1:3) = 0.0
+  part%uf = 0.0
   part%Tf = 0.0
   part%qinf = 0.0
   do i=0,1
@@ -1780,6 +1785,20 @@ CONTAINS
       mult_c = mult_init*(1+4.8081e-04*mult_factor)/(mult_factor*(1+4.8081e-04))
 
 
+      !Set up the histograms
+      hist_rad = 0.0
+      hist_raddeath = 0.0
+      bins_rad = 0.0
+      hist_res = 0.0
+      bins_res = 0.0
+      hist_actres = 0.0
+      bins_actres = 0.0
+      hist_acttodeath = 0.0
+      bins_acttodeath = 0.0
+      hist_numact = 0.0
+      bins_numact = 0.0
+
+
       !set_binsdata does logarithmic binning!
       !Radius histogram
       call set_binsdata(bins_rad,histbins+2,1.0e-8,1.0e-3)
@@ -1795,7 +1814,6 @@ CONTAINS
 
       !Num activations histogram
       call set_binsdata_integer(bins_numact,histbins+2,0.0)
-
 
       !Initialize the linked list of particles:
       nullify(part,first_particle)

--- a/particles.f90
+++ b/particles.f90
@@ -2676,8 +2676,6 @@ CONTAINS
 
             call create_particle(xp_init,vp_init,Tp_init,m_s,kappa_s,mult,rad_init,idx_old,procidx_old)
 
-            write(*,'(a8,10e15.6,3i)') 'DHR7:',xp_init,vp_init,Tp_init,m_s,kappa_s,rad_init,idx_old,procidx_old,mult
-
        else
 
             call destroy_particle

--- a/particles.f90
+++ b/particles.f90
@@ -1770,18 +1770,35 @@ CONTAINS
       end if
 
 
-      !Lognormal distribution parameters  -- Must be called even on restart!
-      mult_factor = 25
-      pdf_factor = 4.8081e-04*real(mult_factor)
-      pdf_prob = pdf_factor/(1 + pdf_factor)
+      if (icase.eq.6) then !FATIMA
 
-      !Adjust the multiplicity so that the total number of particles isn't altered:
-      !mult_c = mult_init/mult_factor
-      !mult_a = mult_init/(1.0-pdf_prob)*(1 - pdf_prob/real(mult_factor))
+          !Lognormal distribution parameters  -- Must be called even on restart!
+          !Make sure that the total aerosol number must be the same within each classification
+          !(e.g., # of accumulation particles must be the same no matter mult_factor)
+          mult_factor = 25
+          pdf_factor = 4.8081e-04*real(mult_factor)
+          pdf_prob = pdf_factor/(1 + pdf_factor)
 
-      mult_a = mult_init*(1+4.8081e-04*mult_factor)/(1+4.8081e-04)
+          mult_a = mult_init*(1+4.8081e-04*mult_factor)/(1+4.8081e-04)
+          mult_c = mult_init*(1+4.8081e-04*mult_factor)/(mult_factor*(1+4.8081e-04))
 
-      mult_c = mult_init*(1+4.8081e-04*mult_factor)/(mult_factor*(1+4.8081e-04))
+      elseif (icase.eq.3) then  !CFOG
+
+          mult_factor = 200
+          pdf_factor = 0.02*real(mult_factor)
+          pdf_prob = pdf_factor/(1 + pdf_factor)
+
+          !Adjust the multiplicity so that the total number of particles isn't altered:
+          !Original formulation -- be careful since the number of aerosols in each class different for different mult_factor
+          mult_c = mult_init/mult_factor
+          mult_a = mult_init/(1.0-pdf_prob)*(1 - pdf_prob/real(mult_factor))
+
+      else
+
+          mult_factor = 1.0
+          pdf_prob = 0.0
+
+      end if
 
 
       !Set up the histograms

--- a/particles.f90
+++ b/particles.f90
@@ -119,6 +119,9 @@ CONTAINS
     integer :: rc_s,rc_r,trc_s,trc_r,tc_s,tc_r,tlc_s,tlc_r
     integer :: lc_s,lc_r,blc_s,blc_r,bc_s,bc_r,brc_s,brc_r
 
+    !Tmp array
+    real :: arg_tmp(1:nnx,iys:iye,izs-1:ize+1)
+
     !Debugging:
     real :: xv,yv,zv
 
@@ -134,19 +137,28 @@ CONTAINS
     !First fill the center, since this is just u,v,w on that proc:
 
     !In the column setup, need to tranpose u,v,w first into u_t,v_t,w_t:
-    call xtoz_trans(u(1:nnx,iys:iye,izs-1:ize+1),u_t,nnx,nnz, &
+    arg_tmp = u(1:nnx,iys:iye,izs-1:ize+1)
+    call xtoz_trans(arg_tmp,u_t,nnx,nnz, &
     mxs,mxe,mx_s,mx_e,iys,iye,izs,ize,iz_s,iz_e, &
     myid,ncpu_s,numprocs)
-    call xtoz_trans(v(1:nnx,iys:iye,izs-1:ize+1),v_t,nnx,nnz, &
+
+    arg_tmp = v(1:nnx,iys:iye,izs-1:ize+1)
+    call xtoz_trans(arg_tmp,v_t,nnx,nnz, &
     mxs,mxe,mx_s,mx_e,iys,iye,izs,ize,iz_s,iz_e, &
     myid,ncpu_s,numprocs)
-    call xtoz_trans(w(1:nnx,iys:iye,izs-1:ize+1),w_t,nnx,nnz, &
+
+    arg_tmp = w(1:nnx,iys:iye,izs-1:ize+1)
+    call xtoz_trans(arg_tmp,w_t,nnx,nnz, &
     mxs,mxe,mx_s,mx_e,iys,iye,izs,ize,iz_s,iz_e, &
     myid,ncpu_s,numprocs)
-    call xtoz_trans(t(1:nnx,iys:iye,1,izs-1:ize+1),T_t,nnx,nnz, &
+
+    arg_tmp = t(1:nnx,iys:iye,1,izs-1:ize+1)
+    call xtoz_trans(arg_tmp,T_t,nnx,nnz, &
     mxs,mxe,mx_s,mx_e,iys,iye,izs,ize,iz_s,iz_e, &
     myid,ncpu_s,numprocs)
-    call xtoz_trans(t(1:nnx,iys:iye,2,izs-1:ize+1),T2_t,nnx,nnz, &
+
+    arg_tmp = t(1:nnx,iys:iye,2,izs-1:ize+1)
+    call xtoz_trans(arg_tmp,T2_t,nnx,nnz, &
     mxs,mxe,mx_s,mx_e,iys,iye,izs,ize,iz_s,iz_e, &
     myid,ncpu_s,numprocs)
 

--- a/particles.f90
+++ b/particles.f90
@@ -3655,12 +3655,29 @@ CONTAINS
 
       phiw = phiw/xl/yl/zl/rhoa
       phiv = phiv/xl/yl/zl
-      Rep_avg = Rep_avg/tnumpart
-      radavg = radavg/tnumpart
-      radmsqr = radmsqr/tnumpart
-      tavgres = tavgres/tnum_destroy
-      radavg_center = radavg_center/tnumdrop_center
-      radmsqr_center = radmsqr_center/tnumdrop_center
+      if (tnumpart.eq.0) then
+         Rep_avg = 0.0
+         radavg = 0.0
+         radmsqr = 0.0
+      else
+         Rep_avg = Rep_avg/tnumpart
+         radavg = radavg/tnumpart
+         radmsqr = radmsqr/tnumpart
+      end if
+      
+      if (tnum_destroy.eq.0) then
+         tavgres = 0.0
+      else
+         tavgres = tavgres/tnum_destroy
+      end if
+ 
+      if (tnumdrop_center.eq.0) then
+         radavg_center = 0.0
+         radmsqr_center = 0.0
+      else
+         radavg_center = radavg_center/tnumdrop_center
+         radmsqr_center = radmsqr_center/tnumdrop_center
+      end if
 
       !Min and max radius
       call mpi_allreduce(myradmin,radmin,1,mpi_real8,mpi_min,mpi_comm_world,ierr)

--- a/particles.f90
+++ b/particles.f90
@@ -2149,7 +2149,6 @@ CONTAINS
 
   !C-FOG and FATIMA parameters: lognormal of accumulation + lognormal of coarse, with extra "resolution" on the coarse mode
   real :: S,M,kappa_s,rad_init
-  real :: num_a,num_c,totnum_a,totnum_c
   integer*8 :: mult
 
   if (inewpart.eq.1) then  !Simple: properties as in params.in, randomly located in domain
@@ -2205,7 +2204,6 @@ CONTAINS
 
          !With these parameters, get m_s and rad_init from distribution
          call lognormal_dist(rad_init,m_s,kappa_s,M,S)
-         num_a = num_a + 1
 
       else  !It's coarse mode
 
@@ -2216,7 +2214,6 @@ CONTAINS
 
          !With these parameters, get m_s and rad_init from distribution
          call lognormal_dist(rad_init,m_s,kappa_s,M,S)
-         num_c = num_c + 1
 
       end if      
 
@@ -2294,7 +2291,6 @@ CONTAINS
 
          !With these parameters, get m_s and rad_init from distribution
          call lognormal_dist(rad_init,m_s,kappa_s,M,S)
-         num_a = num_a + 1
 
       else  !It's coarse mode
 
@@ -2305,7 +2301,6 @@ CONTAINS
 
          !With these parameters, get m_s and rad_init from distribution
          call lognormal_dist(rad_init,m_s,kappa_s,M,S)
-         num_c = num_c + 1
 
       end if
 
@@ -2575,7 +2570,6 @@ CONTAINS
 
   !C-FOG and FATIMA parameters: lognormal of accumulation + lognormal of coarse, with extra "resolution" on the coarse mode
   real :: S,M,kappa_s,rad_init
-  real :: num_a,num_c,totnum_a,totnum_c
   integer*8 :: mult
 
 


### PR DESCRIPTION
After an issue was discovered for one of the past test cases: the FATIMA test case appeared to be running correctly, but then crashed after 1.2 hours unexpectedly, and with no obvious reason. This kicked off a number of debugging steps. 

To detect potential memory and initialization issues, compiled with:

`-g -traceback -check all,noarg_temp_created -fpe0 -init=arrays -init=snan` 

This led to many small issues that were sorted out, many of which had been hidden for a while. A few original subroutines in `les.F` needed an `implicit none` to prevent incorrect assumptions about function types (namely `mod_magnus` was causing strange problems). Ultimately, it led to fixing a bug with `dtzdf` not being initialized, which was causing the original problem. Many of these updates were unrelated to the original issue.