### PR TITLE
Debugging builds are possible via the DEBUG=yes build variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,54 @@ ifeq ($(ARCH), avx2)
 ARCH_FLAGS = -march=core-avx2
 endif
 
-FLAGS=-i4 -r8 -O2 -assume byterecl $(ARCH_FLAGS) -fpp
+# Always used compilation flags:
+#
+#   -i4               Use 32-bit integers
+#   -r2               Use 64-bit floating point values
+#   -assume byterecl  Interpret open()'s recl option in bytes to eliminate
+#                     Fortran record headers being used in binary files.
+#   $(ARCH_FLAGS)     Architecture-specific flags, from above
+#   -fpp              Enable pre-processing of source files regardless of extension
+#   -traceback        Generate detailed stack traces when run-time errors occur.
+#                     This doesn't have a performance cost as it only modifies
+#                     the error code path.  Note that it does not depend on the
+#                     level of debugging support.
+#
+FLAGS=-i4 -r8 -assume byterecl $(ARCH_FLAGS) -fpp -traceback
 
-## UNCOMMENT TO RUN IN DEBUG MODE
-DEBUG_FLAGS=-g -traceback
-#DEBUG_FLAGS+=-check all,noarg_temp_created
-#DEBUG_FLAGS+=-fpe0
-#DEBUG_FLAGS+=-init=arrays -init=snan
+# Are we building a debug build?  This enables options useful for debugging
+# the solver's behavior but are not desirable to unconditionally enable.
+# See below for details.
+ifeq ($(DEBUG), yes)
+
+# Generate debugging information.  This is necessary for running the solver
+# under a debugger and can be useful for other tools (e.g. profilers).
+#
+# NOTE: This disables optimizations and enables run-time checks!
+#
+DEBUG_FLAGS = -g
+
+# Enable all compilation warnings except for when temporary arrays are created
+# when passing to a subroutine or Fortran.  Temporary arrays occur throughout
+# the code base and will be addressed at a later date.
+DEBUG_FLAGS += -check all,noarg_temp_created
+
+# Exit with a SIGFPE whenever a floating point exception (FPE) is detected.
+# This is useful for identifying precisely where an invalid value (infinities
+# and NaNs) are introduced.
+DEBUG_FLAGS += -fpe0
+
+# Initialize floating point values, both scalars and arrays, with signalling
+# NaNs.  Combined with exiting on FPEs this makes it trivial to identify the use
+# of uninitialized floating point values.
+DEBUG_FLAGS += -init=arrays -init=snan
+
+else # DEBUG == no
+
+# Enable optimizations that are almost always beneficial.
+FLAGS += -O2
+
+endif
 
 # NetCDF output is always enabled.
 OUTPUTINC = -I$(NETCDFBASE)/include


### PR DESCRIPTION
Updated the Makefile so debugging builds can be enabled without modifying the Makefile itself.  Now, specifying DEBUG=yes will enable a debug build that identifies several classes of issues (e.g. out of bounds array accesses, use of uninitialized variables, etc) that are otherwise difficult to track down.  Optimized builds remain the default as the DEBUG build variable does not have a default value.

I recommend merging with rebase.