### PR TITLE
Test cases and tutorials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ case1
 *.o
 lesmpi.a
 mach.file
+test_cases/*/cou.mp.*.out
+test_cases/*/test_case_*

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,19 @@ FLAGS += -O2
 
 endif
 
-# NetCDF output is always enabled.
+# NetCDF output is always enabled.  Make sure we can find its headers and
+# libraries.
+ifeq ($(strip $(NETCDFBASE)),)
+
+# Don't enforce the variable being set if we just want to clean the directory.
+ifneq ($(strip $(MAKECMDGOALS)), clean)
+$(info NETCDFBASE is not set!  Did you forget to load a module (e.g. mvapich2)? )
+$(info )
+$(error "Please set NETCDFBASE to the location of the netCDF install." )
+endif
+
+endif
+
 OUTPUTINC = -I$(NETCDFBASE)/include
 OUTPUTLIB = -L$(NETCDFBASE)/lib
 LINKOPTS  = -lnetcdf -lnetcdff

--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,54 @@ ifeq ($(ARCH), avx2)
 ARCH_FLAGS = -march=core-avx2
 endif
 
-FLAGS=-i4 -r8 -O2 -assume byterecl $(ARCH_FLAGS) -fpp
+# Always used compilation flags:
+#
+#   -i4               Use 32-bit integers
+#   -r2               Use 64-bit floating point values
+#   -assume byterecl  Interpret open()'s recl option in bytes to eliminate
+#                     Fortran record headers being used in binary files.
+#   $(ARCH_FLAGS)     Architecture-specific flags, from above
+#   -fpp              Enable pre-processing of source files regardless of extension
+#   -traceback        Generate detailed stack traces when run-time errors occur.
+#                     This doesn't have a performance cost as it only modifies
+#                     the error code path.  Note that it does not depend on the
+#                     level of debugging support.
+#
+FLAGS=-i4 -r8 -assume byterecl $(ARCH_FLAGS) -fpp -traceback
 
-## UNCOMMENT TO RUN IN DEBUG MODE
-DEBUG_FLAGS=-g -traceback
-#DEBUG_FLAGS+=-check all,noarg_temp_created
-#DEBUG_FLAGS+=-fpe0
-#DEBUG_FLAGS+=-init=arrays -init=snan
+# Are we building a debug build?  This enables options useful for debugging
+# the solver's behavior but are not desirable to unconditionally enable.
+# See below for details.
+ifeq ($(DEBUG), yes)
+
+# Generate debugging information.  This is necessary for running the solver
+# under a debugger and can be useful for other tools (e.g. profilers).
+#
+# NOTE: This disables optimizations and enables run-time checks!
+#
+DEBUG_FLAGS = -g
+
+# Enable all compilation warnings except for when temporary arrays are created
+# when passing to a subroutine or Fortran.  Temporary arrays occur throughout
+# the code base and will be addressed at a later date.
+DEBUG_FLAGS += -check all,noarg_temp_created
+
+# Exit with a SIGFPE whenever a floating point exception (FPE) is detected.
+# This is useful for identifying precisely where an invalid value (infinities
+# and NaNs) are introduced.
+DEBUG_FLAGS += -fpe0
+
+# Initialize floating point values, both scalars and arrays, with signalling
+# NaNs.  Combined with exiting on FPEs this makes it trivial to identify the use
+# of uninitialized floating point values.
+DEBUG_FLAGS += -init=arrays -init=snan
+
+else # DEBUG == no
+
+# Enable optimizations that are almost always beneficial.
+FLAGS += -O2
+
+endif
 
 # NetCDF output is always enabled.
 OUTPUTINC = -I$(NETCDFBASE)/include

--- a/les.run
+++ b/les.run
@@ -11,8 +11,8 @@ case=case1
 time=0000000
 runout=$case.out.$time
 
-datadir=/scratch365/PATH_TO_SCRATCH/$case
-homedir=~/PATH_TO_RUN/$case
+datadir=PATH_TO_SCRATCH/$case
+homedir=PATH_TO_CODE/$case
 
 cd $homedir
 
@@ -25,5 +25,3 @@ echo $imachine > ./mach.file
 echo $datadir >> ./mach.file
 
 mpirun -n 64 $homedir/../lesmpi.a $homedir/params.in > $datadir/$runout
-
-

--- a/params_PI_CHAMBER.in
+++ b/params_PI_CHAMBER.in
@@ -2,11 +2,11 @@
 !Time step information
 &step_params
 iti=0        !Time step to begin
-itmax=500   !Max number of time steps
+itmax=10000   !Max number of time steps
 imean=100    !Number of time steps between writing mean profiles to output log file
 ihst=50     !Number of time steps between writing profiles to history file
 itape=5000  !Number of time steps before opening new history file and writing full 3D volumes
-i_viz=1000   !Time steps between writing to viz file
+i_viz=10   !Time steps between writing to viz file
 itn = 0  !Index for "u.le.cou001" files
 max_time = 1.0e9  !Code will stop at the next itape after this time (in seconds) has been exceeded
 /
@@ -19,7 +19,7 @@ method=3, idebug=1, ivis0=1, ifix_dt=0, new_vis=-1
 isfc = 1, 1  ! isfc = 0 sets surface flux (qstar), isfc = 1 sets surface condition (Dirichlet through tsfcc)
 iz_space=1, ! 0 = uniform dz, 1 = top/bottom mirror stretched ("channel"), 2 = "open channel", 3 = PBL with stretching at surface and at zi
 iDNS = 1
-ifields = 0  ! if set to 1, reads the initial condition from path_ran below; otherwise calls subroutine random
+ifields = 1  ! if set to 1, reads the initial condition from path_ran below; otherwise calls subroutine random
 ihurr = 0  !If set to 1, includes the hurricane forcings from Bryan et al. (2017) BLM and according to dvdr and hurr_rad below
 ilin = 1   !1 means linear interpolation for particle, 6th order otherwise
 icouple=1
@@ -37,9 +37,9 @@ iexner = 0  !iexner = 1 applies a correction to part%Tf to account for conversio
 ilongwave = 0   !Use simple longwave radiation scheme when clouds/fog present
 inetcdf = 1  !Set to 1 to output history and histogram data to netcdf format, otherwise original binary format
 iviznetcdf = 1  !Set to 1 to slice viz files to netcdf format (WARNING: it's been a long time since the original have been used)
-ihumiditycontrol = 1  !Adaptive humidity source/sink (used for Pi Chamber; subroutine humidity_control)
-ireintro=0   !Aerosol injection
-itrajout=0   !Write the particle trajectory files. Needs a directory within the scratch space, and each processor writes a file (requires postprocessing to stitch together)
+ihumiditycontrol = 0  !Adaptive humidity source/sink (used for Pi Chamber; subroutine humidity_control)
+ireintro=1   !Aerosol injection
+itrajout=1   !Write the particle trajectory files. Needs a directory within the scratch space, and each processor writes a file (requires postprocessing to stitch together)
 /
 
 !Grid and domain parameters
@@ -71,8 +71,7 @@ hurr_rad = 40e3  ! Hurricane radius
 
 dpdx = 0.0  !The pressure gradient for channel flow (gets put into u_geo for DNS)
 
-!Swall = -2.15e-6  !Set the CONSTANT humidity sink to use if ihumiditycontrol = 0
-Swall = -4.96e-6  !Set the CONSTANT humidity sink to use if ihumiditycontrol = 0
+Swall = -2.15e-6  !Set the CONSTANT humidity sink to use if ihumiditycontrol = 0
 
 zi = 1.0  !This has to do with grid stretching; make equal to zl for iz_space = 1,2; zi is inversion height for iz_space = 3
 zl = 1.0

--- a/postprocessing/history_postprocessing.m
+++ b/postprocessing/history_postprocessing.m
@@ -1,0 +1,91 @@
+clear
+clc
+close all
+
+%The "history file" contains quantities that have been averaged either volumetrically or horizontally
+%The frequency that this is written out is governed by the "ihist" paramater in params.in
+%To see the contents of the file within Matlab, use the "ncdisp" command
+
+%"history.nc" is a netCDF file which can be read using standard packages
+
+
+fname = './history.nc';
+
+%% Plot the volume-averaged relative humidity versus time
+
+%Load the time and meanRH variables:
+time = ncread(fname,'time');
+meanRH = ncread(fname,'meanRH');
+
+figure(1)
+plot(time,meanRH,'linewidth',2)
+xlabel('time [s]')
+ylabel('Volume-average relative humidity [%]')
+
+
+%% Plot the average radius of all particles versus time
+
+radavg = ncread(fname,'radavg');
+
+figure(2)
+plot(time,radavg,'linewidth',2)
+xlabel('time [s]')
+ylabel('Average radius of all particles [m]')
+
+
+%% Plot the water vapor mixing ratio versus time
+
+txym = ncread(fname,'txym');  %"txym" contains BOTH potential temperature (theta) and water vapor mixing ratio (qv)
+qxym = squeeze(txym(:,2,:));
+
+zu = ncread(fname,'zu'); %"zu" is the vertical grid points at the locations which contain u, v, and scalars. "zw" is the height which contains w and fluxes
+
+
+%Multiple ways of plotting the vertical profile versus height
+
+%1. Animate
+
+Nt = length(time); %Number of time steps
+stride = 10; %Don't necessarily want to animate each frame
+figure(3)
+for i=1:stride:Nt
+
+    figure(3); clf
+    plot(qxym(:,i),zu(:,i),'linewidth',2)
+    xlabel('qv [kg/kg]')
+    ylabel('z [m]')
+    drawnow
+
+end
+
+
+%2. Plot as a time-height contour
+Nz = length(zu(:,1)); %Number of u-level grid points in z
+
+%Make 2D arrays to plot agains
+Z = repmat(zu(:,1),1,Nt);
+T = repmat(time(:)',Nz,1);
+
+clevels = linspace(0.01,0.02,100);
+
+figure(4)
+contourf(T,Z,qxym,clevels,'edgecolor','none')
+colorbar
+title('qv [kg/kg]')
+xlabel('time [s]')
+ylabel(['z [m]'])
+
+
+%3. Perform a time average
+
+%Need to know the time index beyond which it is appropriate to average (after statistical stationarity)
+%Here take 100
+
+tidx = 100;
+
+qxym_avg = mean(qxym(:,tidx:end),2);
+
+figure(5)
+plot(qxym_avg,zu(:,1),'linewidth',2)
+xlabel('<qv> [kg/kg]')
+ylabel('z [m]')

--- a/postprocessing/viz_postprocessing.m
+++ b/postprocessing/viz_postprocessing.m
@@ -1,0 +1,77 @@
+
+
+%The "viz file" contains slices of velocities and scalars
+%The frequency that this is written out is governed by the "i_viz" paramater in params.in
+%To see the contents of the file within Matlab, use the "ncdisp" command
+%By default the slices are at the midplanes in each direction; to change, see the subroutine "write_viz_netcdf"
+
+%"viz.nc" is a netCDF file which can be read using standard packages
+
+
+clear
+clc
+close all
+
+fname = './viz.nc';
+
+%% Animate an xy-slice of potential temperature
+
+time = ncread(fname,'time');
+Nt = length(time);
+
+x = ncread(fname,'x');
+Nx = length(x);
+
+y = ncread(fname,'y');
+Ny = length(y);
+
+
+X = repmat(x,1,Ny);
+Y = repmat(y',Nx,1);
+
+t_xy = ncread(fname,'t_xy');
+
+min_t = min(min(min(t_xy)));
+max_t = max(max(max(t_xy)));
+clevels = linspace(min_t,max_t,100);
+
+figure(1)
+for i=1:Nt
+
+    figure(1); clf
+    contourf(X,Y,t_xy(:,:,i),clevels,'edgecolor','none')
+    colorbar
+    caxis([min_t max_t])
+    xlabel('x [m]')
+    ylabel('y [m]')
+    drawnow
+
+end
+
+
+%% Animate yz-slice of vertical velocity [NOTE: truncates the z = 0 point to make the same size as the u, v, scalar arrays]
+
+z = ncread(fname,'zu');
+Nz = length(z);
+
+w_yz = ncread(fname,'w_yz');
+
+Y = repmat(y,1,Nz);
+Z = repmat(z',Ny,1);
+
+min_w = min(min(min(w_yz)));
+max_w = max(max(max(w_yz)));
+clevels = linspace(min_w,max_w,100);
+
+figure(2)
+for i=1:Nt
+
+    figure(2); clf
+    contourf(Y,Z,w_yz(:,:,i),clevels,'edgecolor','none')
+    colorbar
+    caxis([min_w max_w])
+    xlabel('y [m]')
+    ylabel('z [m]')
+    drawnow
+
+end

--- a/test_cases/README.md
+++ b/test_cases/README.md
@@ -1,0 +1,26 @@
+# Running Test Case Simulations
+Each of the test case directories contains the following files to support
+running test case simulations:
+
+* `params.in` - Simulation parameters file
+* `<test_case>.run` - Job submission script to launch the `<test_case>` test
+  case
+
+The files above need to be modified before they can be used with and to launch
+the simulation.  Each are templates that have the following placeholders that
+need to be replaced:
+
+* `PATH_TO_SCRATCH` - Location of the simulation's outputs.  For simulations
+  running on Notre Dame systems, this must be beneath `/scratch365`
+* `PATH_TO_CODE` - Location of the NTLP repository's working copy
+
+The following commands will modify both `params.in` and `<test_case>.run`.  They
+assume they are run from the `test_cases/` directory.  Change `TEST_CASE` as
+appropriate.
+
+```shell
+TEST_CASE=pi_chamber
+sed -i -e "s#PATH_TO_SCRATCH#/scratch365/${USER}#" ${TEST_CASE}/params.in
+sed -i -e "s#PATH_TO_SCRATCH#/scratch365/${USER}#" \
+       -e "s#PATH_TO_CODE#${HOME}/NTLP#" ${TEST_CASE}/${TEST_CASE}.run
+```

--- a/test_cases/cfog/cfog.run
+++ b/test_cases/cfog/cfog.run
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+group_storage=/afs/crc.nd.edu/group/RichterLab
+
+#$ -M YOUR_EMAIL@nd.edu
+#$ -m n
+#$ -pe mpi-16 64
+#$ -q *@@richter
+#$ -N test_case_cfog
+#$ -j y
+
+case=cfog
+time=0000000
+runout=$case.out.$time
+
+datadir=PATH_TO_SCRATCH/$case
+homedir=PATH_TO_CODE/test_cases/$case
+
+# create the directory for the output.
+mkdir -p $datadir
+
+cd $homedir
+
+module load mvapich2
+module load intel
+module load netcdf
+
+imachine=0
+echo $imachine > ./mach.file
+echo $datadir >> ./mach.file
+
+mpirun -n 64 $homedir/../../lesmpi.a $homedir/params.in > $datadir/$runout

--- a/test_cases/cfog/params.in
+++ b/test_cases/cfog/params.in
@@ -1,0 +1,138 @@
+
+!Time step information
+&step_params
+iti=0          !Time step to begin
+itmax=500000   !Max number of time steps
+imean=100    !Number of time steps between writing mean profiles to output log file
+ihst=100     !Number of time steps between writing profiles to history file
+itape=5000  !Number of time steps before opening new history file and writing full 3D volumes
+i_viz=100   !Time steps between writing to viz file
+itn = 0  !Index for "u.le.cou001" files
+max_time = 28800  !Code will stop at the next itape after this time (in seconds) has been exceeded
+/
+
+!Flags for various features
+&flags
+ismlt=0, ifree=0, iradup=0, iupwnd=1
+ibuoy=1, ifilt=0, itcut=1, isubs=0, ibrcl=0, iocean=0
+method=3, idebug=1, ivis0=1, ifix_dt=0, new_vis=-1
+isfc = 1, 1  ! isfc = 0 sets surface flux (qstar), isfc = 1 sets surface condition (Dirichlet through tsfcc)
+iz_space=2, ! 0 = uniform dz, 1 = top/bottom mirror stretched ("channel"), 2 = "open channel", 3 = PBL with stretching at surface and at zi
+iDNS = 0
+ifields = 0  ! if set to 1, reads the initial condition from path_ran below; otherwise calls subroutine random
+ihurr = 0  !If set to 1, includes the hurricane forcings from Bryan et al. (2017) BLM and according to dvdr and hurr_rad below
+ilin = 1   !1 means linear interpolation for particle, 6th order otherwise
+icouple=1
+iTcouple=1
+iHcouple=1  !iHcouple also controls TE couple
+ievap=1
+ineighbor=0
+icoalesce=0
+ipart_method=2   !1 = same RK3 as flow, 2 = backward Euler
+ipartdiff = 1
+inewpart = 3  !1 = new particles have initial conditions defined below, random location in domain; 2 = same, but normal distributions of radius and kappa_s, given by radius_std and kappas_std; 3 = special setup for C-FOG and double lognormal of different type; 4 = crude sea spray setup
+icase = 3  !Special additions for certain cases. 3 = setup for C-FOG, 4 = steady state LES sea spray setup
+isfs = 2   !isfs=1 is simple random walk, isfs=2 is Weil et al. (2004) particle subgrid
+iexner = 1  !iexner = 1 applies a correction to part%Tf to account for conversion b/w potential temp and temp. (need in PBL)
+ilongwave = 1   !Use simple longwave radiation scheme when clouds/fog present
+inetcdf = 1  !Set to 1 to output history and histogram data to netcdf format, otherwise original binary format
+iviznetcdf = 1  !Set to 1 to slice viz files to netcdf format (WARNING: it's been a long time since the original have been used)
+ihumiditycontrol = 0  !Adaptive humidity source/sink (used for Pi Chamber; subroutine humidity_control)
+ireintro=1   !Aerosol injection
+itrajout=1   !Write the particle trajectory files. Needs a directory within the scratch space, and each processor writes a file (requires postprocessing to stitch together)
+/
+
+!Grid and domain parameters
+&grid_params
+ncpu_s=8
+
+!Time step
+cfl = 0.9
+dt_new = 1.0
+
+!Use for DNS:
+Uo = 0.0  !Sets the magnitude of the top and bottom plate velocities (Couette flow -- assumes equal and opposite)
+Ttop(1) = 280.0, 100.0  !Currently this should be (temperature, relative humidity) (used in DNS)
+Tbot(1) = 299.0, 100.0  !Currently this should be (temperature, relative humidity) (used in DNS)
+
+!Use for LES:
+qstar = 0.2, 0.2  !Surface fluxes of (temperature, humidity) (used for LES and DNS)
+tsfcc = 283.9, 100.0    !Surface conditions of (temp, humidity) (used for LES) -- make sure tsfcc is gt than t00 for both isfc=0 or 1
+
+surf_RH = 100.0
+surf_temp = 282.0  !Only use this when changing the surface temperature in time! Otherwise set tsfcc
+
+psurf = 101325  !Pa -- nominal surface pressure, for use in the definition of potential temp
+
+ugcont = 4.0   !The initial u-velocity in the field
+vgcont = 0.0   !The initial v-velocity
+dvdr = -4.0e-04  !Change in v with hurricane radius
+hurr_rad = 40e3  ! Hurricane radius
+
+dpdx = 0.0  !The pressure gradient for channel flow (gets put into u_geo for DNS)
+
+Swall = 0  !Set the CONSTANT humidity sink to use if ihumiditycontrol = 0
+
+zi = 80.0  !This has to do with grid stretching; make equal to zl for iz_space = 1,2; zi is inversion height for iz_space = 3
+zl = 80.0
+xl = 128.0
+yl = 128.0
+
+zw1 = 0.1  !The first grid point; only used if stretched grid
+
+!Radiation parameters
+rad_kappa = 120.0  !The absorptivity in the radiation expression (see Larson et al. 2007)
+rad_Fct = 60.0    !Net radiative flux at cloud (or domain) top
+rad_Fcb = 0.0    !Net radiative flux at cloud (or domain) base
+
+/
+
+!Set the paths for code I/O. Must be on the scratch directory, not AFS!
+&path_names
+path_seed="PATH_TO_SCRATCH/cfog/"
+path_part="PATH_TO_SCRATCH/cfog/part.le.cou005"
+path_res="PATH_TO_SCRATCH/cfog/u.le.cou005"
+path_ran="PATH_TO_SCRATCH/cfog/u.le.cou000"
+/
+
+
+!Material and particle properties and other constants
+&constants
+grav = 9.81
+t00 = 273.0 !Reference temp for buoyancy
+fcor = 1.0e-4  !Coriolis parameter
+zo = 3.2e-5       !Roughness height (for LES)
+zos = 3.2e-5       !Scalar roughness height (for LES)
+
+!Air phase:
+rhoa=1.2
+nuf=1.57e-5  !m^2/s
+Cpa=1006.0  !J/kg-K
+Pra = 0.715
+Sc = 0.615
+Rd = 286.9     !J/kg-K  dry air gas constant
+
+!Particles:
+tnumpart = 1e6
+mult_init = 1.75e9
+rhow=1000.0  !kg/m^3
+rhos = 2000.0 !Density of salt, kg/m^3
+part_grav = 0,0,-9.81
+Cpp = 4179.0  !J/kg-K
+Mw = 0.018015  !kg/mol
+Ru = 8.3144    !J/mol-K Universal gas constant
+Ms = 0.05844  !kg/mol: molecular weight of salt
+Sal = 0.034  !INITIAL salinity in kg/kg
+Gam = 7.28e-2
+Ion = 2.0
+
+nprime = 0.01  !particles/cm^3/min, real rate is nprime*multiplicity
+
+!Particle initial conditions:
+radius_init=2.5e-6
+radius_std=0.0
+kappas_init=1.2
+kappas_std=0.00
+Tp_init = 282.0
+vp_init = 0.0, 0.0, 0.0
+/

--- a/test_cases/channel/channel.run
+++ b/test_cases/channel/channel.run
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+group_storage=/afs/crc.nd.edu/group/RichterLab
+
+#$ -M YOUR_EMAIL@nd.edu
+#$ -m n
+#$ -pe mpi-16 64
+#$ -q *@@richter
+#$ -N test_case_channel
+#$ -j y
+
+case=channel
+time=0000000
+runout=$case.out.$time
+
+datadir=PATH_TO_SCRATCH/$case
+homedir=PATH_TO_CODE/test_cases/$case
+
+# create the directory for the output.
+mkdir -p $datadir
+
+cd $homedir
+
+module load mvapich2
+module load intel
+module load netcdf
+
+imachine=0
+echo $imachine > ./mach.file
+echo $datadir >> ./mach.file
+
+mpirun -n 64 $homedir/../../lesmpi.a $homedir/params.in > $datadir/$runout

--- a/test_cases/channel/params.in
+++ b/test_cases/channel/params.in
@@ -1,0 +1,142 @@
+
+!Time step information
+&step_params
+iti=0        !Time step to begin
+itmax=500000   !Max number of time steps
+imean=100    !Number of time steps between writing mean profiles to output log file
+ihst=50     !Number of time steps between writing profiles to history file
+itape=10000  !Number of time steps before opening new history file and writing full 3D volumes
+i_viz=50   !Time steps between writing to viz file
+itn = 0  !Index for "u.le.cou001" files
+max_time = 1.0e9  !Code will stop at the next itape after this time (in seconds) has been exceeded
+/
+
+!Flags for various features
+&flags
+ismlt=0, ifree=0, iradup=0, iupwnd=1
+ibuoy=0, ifilt=0, itcut=1, isubs=0, ibrcl=0, iocean=0
+method=3, idebug=1, ivis0=1, ifix_dt=0, new_vis=-1
+isfc = 1, 1  ! isfc = 0 sets surface flux (qstar), isfc = 1 sets surface condition (Dirichlet through tsfcc)
+iz_space=1, ! 0 = uniform dz, 1 = top/bottom mirror stretched ("channel"), 2 = "open channel", 3 = PBL with stretching at surface and at zi
+iDNS = 1
+ifields = 0  ! if set to 1, reads the initial condition from path_ran below; otherwise calls subroutine random
+ihurr = 0  !If set to 1, includes the hurricane forcings from Bryan et al. (2017) BLM and according to dvdr and hurr_rad below
+ilin = 1   !1 means linear interpolation for particle, 6th order otherwise
+icouple=0
+iTcouple=0
+iHcouple=0  !iHcouple also controls TE couple
+ievap=0
+ineighbor=0
+icoalesce=0
+ipart_method=2   !1 = same RK3 as flow, 2 = backward Euler
+ipartdiff = 0
+inewpart = 1  !1 = new particles have initial conditions defined below, random location in domain; 2 = same, but normal distributions of radius and kappa_s, given by radius_std and kappas_std; 3 = special setup for C-FOG and double lognormal of different type; 4 = crude sea spray setup
+icase = 0  !Special additions for certain cases. 3 = setup for C-FOG, 4 = steady state LES sea spray setup
+isfs = 2   !isfs=1 is simple random walk, isfs=2 is Weil et al. (2004) particle subgrid
+iexner = 0  !iexner = 1 applies a correction to part%Tf to account for conversion b/w potential temp and temp. (need in PBL)
+ilongwave = 0   !Use simple longwave radiation scheme when clouds/fog present
+inetcdf = 1  !Set to 1 to output history and histogram data to netcdf format, otherwise original binary format
+iviznetcdf = 1  !Set to 1 to slice viz files to netcdf format (WARNING: it's been a long time since the original have been used)
+ihumiditycontrol = 0  !Adaptive humidity source/sink (used for Pi Chamber; subroutine humidity_control)
+ireintro=0   !Aerosol injection
+itrajout=0   !Write the particle trajectory files. Needs a directory within the scratch space, and each processor writes a file (requires postprocessing to stitch together)
+/
+
+!Grid and domain parameters
+&grid_params
+ncpu_s=8
+
+!Time step
+cfl = 0.8
+dt_new = 0.05
+
+!Use for DNS:
+Uo = 0.0  !Sets the magnitude of the top and bottom plate velocities (Couette flow -- assumes equal and opposite)
+Ttop(1) = 280.0, 100.0  !Currently this should be (temperature, relative humidity) (used in DNS)
+Tbot(1) = 299.0, 100.0  !Currently this should be (temperature, relative humidity) (used in DNS)
+
+!Use for LES:
+qstar = 0.2, 0.2  !Surface fluxes of (temperature, humidity) (used for LES and DNS)
+tsfcc = 300.0, 100.0    !Surface conditions of (temp, humidity) (used for LES) -- make sure tsfcc is gt than t00 for both isfc=0 or 1
+
+surf_RH = 100.0
+surf_temp = 282.0  !Only use this when changing the surface temperature in time! Otherwise set tsfcc
+
+psurf = 101325  !Pa -- nominal surface pressure, for use in the definition of potential temp
+
+ugcont = 0.0   !The initial u-velocity in the field
+vgcont = 0.0   !The initial v-velocity
+dvdr = -8.0e-04  !Change in v with hurricane radius
+hurr_rad = 40e3  ! Hurricane radius
+
+dpdx = -0.69325  !The pressure gradient for channel flow (gets put into u_geo for DNS)
+
+Swall = 0.0  !Set the CONSTANT humidity sink to use if ihumiditycontrol = 0
+
+zi = 0.04 !This has to do with grid stretching; make equal to zl for iz_space = 1,2; zi is inversion height for iz_space = 3
+zl = 0.04
+xl = 0.251327
+yl = 0.125664
+
+zw1 = 0.00008  !The first grid point; only used if stretched grid
+
+!Radiation parameters
+rad_kappa = 120.0  !The absorptivity in the radiation expression (see Larson et al. 2007)
+rad_Fct = 60.0    !Net radiative flux at cloud (or domain) top
+rad_Fcb = 0.0    !Net radiative flux at cloud (or domain) base
+
+/
+
+!Set the paths for code I/O. Must be on the scratch directory, not AFS!
+&path_names
+
+path_seed="PATH_TO_SCRATCH/channel/"
+path_part="PATH_TO_SCRATCH/channel/part.le.cou002"
+path_res="PATH_TO_SCRATCH/channel/u.le.cou002"
+path_ran="PATH_TO_SCRATCH/channel/u.le.cou000"
+
+/
+
+
+!Material and particle properties and other constants
+&constants
+!grav = 0.043
+grav = 0.545
+t00 = 273.0 !Reference temp for buoyancy
+fcor = 0.0  !Coriolis parameter
+zo = 3.2e-5       !Roughness height (for LES)
+zos = 3.2e-5       !Scalar roughness height (for LES)
+
+!Air phase:
+rhoa=1.0
+nuf=1.57e-5  !m^2/s
+Cpa=1006.0  !J/kg-K
+Pra = 0.715
+Sc = 0.615
+Rd = 286.9     !J/kg-K  dry air gas constant
+
+!Particles:
+tnumpart = 100000
+mult_init = 1.0
+rhow=1000.0  !kg/m^3
+rhos = 2000.0 !Density of salt, kg/m^3
+part_grav = 0,0,0
+Cpp = 4179.0  !J/kg-K
+Mw = 0.018015  !kg/mol
+Ru = 8.3144    !J/mol-K Universal gas constant
+Ms = 0.05844  !kg/mol: molecular weight of salt
+!Sal = 0.034  !INITIAL salinity in kg/kg
+Sal = 0.066  !INITIAL salinity in kg/kg
+Gam = 7.28e-2
+Ion = 2.0
+
+nprime = 0.01  !particles/cm^3/min, real rate is nprime*multiplicity
+
+!Particle initial conditions:
+radius_init=22.8e-6
+radius_std=0.0
+kappas_init=1.2
+kappas_std=0.0
+Tp_init = 290.0
+vp_init = 0.0, 0.0, 0.0
+/

--- a/test_cases/fatima/fatima.run
+++ b/test_cases/fatima/fatima.run
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+group_storage=/afs/crc.nd.edu/group/RichterLab
+
+#$ -M YOUR_EMAIL@nd.edu
+#$ -m n
+#$ -pe mpi-16 64
+#$ -q *@@richter
+#$ -N test_case_fatima
+#$ -j y
+
+case=fatima
+time=0000000
+runout=$case.out.$time
+
+datadir=PATH_TO_SCRATCH/$case
+homedir=PATH_TO_CODE/test_cases/$case
+
+# create the directory for the output.
+mkdir -p $datadir
+
+cd $homedir
+
+module load mvapich2
+module load intel
+module load netcdf
+
+imachine=0
+echo $imachine > ./mach.file
+echo $datadir >> ./mach.file
+
+mpirun -n 64 $homedir/../../lesmpi.a $homedir/params.in > $datadir/$runout

--- a/test_cases/fatima/params.in
+++ b/test_cases/fatima/params.in
@@ -1,0 +1,140 @@
+
+!Time step information
+&step_params
+iti=0          !Time step to begin
+itmax=1000000   !Max number of time steps
+imean=100    !Number of time steps between writing mean profiles to output log file
+ihst=100     !Number of time steps between writing profiles to history file
+itape=1000  !Number of time steps before opening new history file and writing full 3D volumes
+i_viz=100   !Time steps between writing to viz file
+itn = 0  !Index for "u.le.cou001" files
+max_time = 43200.0  !Code will stop at the next itape after this time (in seconds) has been exceeded
+/
+
+!Flags for various features
+&flags
+ismlt=0, ifree=0, iradup=1, iupwnd=1
+ibuoy=1, ifilt=0, itcut=1, isubs=0, ibrcl=0, iocean=0
+method=3, idebug=1, ivis0=1, ifix_dt=0, new_vis=-1
+isfc = 1, 1  ! isfc = 0 sets surface flux (qstar), isfc = 1 sets surface condition (Dirichlet through tsfcc)
+iz_space=2, ! 0 = uniform dz, 1 = top/bottom mirror stretched ("channel"), 2 = "open channel", 3 = PBL with stretching at surface and at zi
+iDNS = 0
+ifields = 0  ! if set to 1, reads the initial condition from path_ran below; otherwise calls subroutine random
+ihurr = 0  !If set to 1, includes the hurricane forcings from Bryan et al. (2017) BLM and according to dvdr and hurr_rad below
+ilin = 1   !1 means linear interpolation for particle, 6th order otherwise
+icouple=1
+iTcouple=1
+iHcouple=1  !iHcouple also controls TE couple
+ievap=1
+ineighbor=0
+icoalesce=0
+ikernel = 1 ! kernel for coalescence; 0 = Golovin; 1 = Geometric kernel with collection efficiencies E=1; 2 = Long kernel; 3 = Geometric kernel with modified Hall collection efficiencies (as in Bott 1998); 4 = Geometric kernel with turbulence-enhanced Hall efficiencies (Wang and Grabowski 2009) (NOT YET)
+ipart_method=2   !1 = same RK3 as flow, 2 = backward Euler
+ipartdiff = 1
+inewpart = 6  !1 = new particles have initial conditions defined below, random location in domain; 2 = same, but normal distributions of radius and kappa_s, given by radius_std and kappas_std; 3 = special setup for C-FOG and double lognormal of different type; 4 = crude sea spray setup; 5 = Sc (preliminary); 6 = FATIMA
+icase = 6  !Special additions for certain cases. 3 = setup for C-FOG, 4 = steady state LES sea spray setup, 5 = Sc (preliminary), 6 = setup for FATIMA
+isfs = 2   !isfs=1 is simple random walk, isfs=2 is Weil et al. (2004) particle subgrid
+iexner = 1  !iexner = 1 applies a correction to part%Tf to account for conversion b/w potential temp and temp. (need in PBL)
+ilongwave = 1   !Use simple longwave radiation scheme when clouds/fog present
+inetcdf = 1  !Set to 1 to output history and histogram data to netcdf format, otherwise original binary format
+iviznetcdf = 1  !Set to 1 to slice viz files to netcdf format (WARNING: it's been a long time since the original have been used)
+ihumiditycontrol = 0  !Adaptive humidity source/sink (used for Pi Chamber; subroutine humidity_control)
+ireintro=1   !Aerosol injection
+itrajout=1   !Write the particle trajectory files. Needs a directory within the scratch space, and each processor writes a file (requires postprocessing to stitch together)
+/
+
+!Grid and domain parameters
+&grid_params
+ncpu_s=8
+
+!Time step
+cfl = 0.5
+dt_new = 1.0
+
+!Use for DNS:
+Uo = 0.0  !Sets the magnitude of the top and bottom plate velocities (Couette flow -- assumes equal and opposite)
+Ttop(1) = 280.0, 100.0  !Currently this should be (temperature, relative humidity) (used in DNS)
+Tbot(1) = 299.0, 100.0  !Currently this should be (temperature, relative humidity) (used in DNS)
+
+!Use for LES:
+qstar = 0.2, 0.2  !Surface fluxes of (temperature, humidity) (used for LES and DNS)
+tsfcc = 287.5, 100.0    !Surface conditions of (temp, humidity) (used for LES) -- make sure tsfcc is gt than t00 for both isfc=0 or 1
+
+surf_RH = 100.0
+surf_temp = 286.5  !Only use this when changing the surface temperature in time! Otherwise set tsfcc
+
+psurf = 101325  !Pa -- nominal surface pressure, for use in the definition of potential temp
+
+ugcont = 4.0   !The initial u-velocity in the field
+vgcont = 0.0   !The initial v-velocity
+dvdr = 0.0  !Change in v with hurricane radius
+hurr_rad = 0.0  ! Hurricane radius
+
+dpdx = 0.0  !The pressure gradient for channel flow (gets put into u_geo for DNS)
+
+Swall = 0.0  !Set the CONSTANT humidity sink to use if ihumiditycontrol = 0
+
+zi = 256.0  !This has to do with grid stretching; make equal to zl for iz_space = 1,2; zi is inversion height for iz_space = 3
+zl = 256.0
+xl = 128.0
+yl = 128.0
+
+zw1 = 0.2  !The first grid point; only used if stretched grid
+
+!Radiation parameters
+rad_kappa = 120.0  !The absorptivity in the radiation expression (see Larson et al. 2007)
+rad_Fct = 67.7    !Net radiative flux at cloud (or domain) top
+rad_Fcb = 0.0    !Net radiative flux at cloud (or domain) base
+
+/
+
+!Set the paths for code I/O. Must be on the scratch directory, not AFS!
+&path_names
+path_seed="PATH_TO_SCRATCH/fatima/"
+path_part="PATH_TO_SCRATCH/fatima/part.le.cou000"
+path_res="PATH_TO_SCRATCH/fatima/u.le.cou000"
+path_ran="PATH_TO_SCRATCH/fatima/u.le.cou000"
+/
+
+
+!Material and particle properties and other constants
+&constants
+grav = 9.81
+t00 = 273.0 !Reference temp for buoyancy
+fcor = 1.009e-04  !Coriolis parameter
+zo = 3.2e-5       !Roughness height (for LES)
+zos = 3.2e-5       !Scalar roughness height (for LES)
+
+!Air phase:
+rhoa=1.2
+nuf=1.57e-5  !m^2/s
+Cpa=1006.0  !J/kg-K
+Pra = 0.715
+Sc = 0.615
+Rd = 286.9     !J/kg-K  dry air gas constant
+
+!Particles:
+tnumpart = 1000000
+mult_init = 629145600
+rhow=1000.0  !kg/m^3
+rhos = 2000.0 !Density of salt, kg/m^3
+part_grav = 0,0,-9.81
+Cpp = 4179.0  !J/kg-K
+Mw = 0.018015  !kg/mol
+Ru = 8.3144    !J/mol-K Universal gas constant
+Ms = 0.05844  !kg/mol: molecular weight of salt
+!Sal = 0.034  !INITIAL salinity in kg/kg
+Sal = 0.066  !INITIAL salinity in kg/kg
+Gam = 7.28e-2
+Ion = 2.0
+
+nprime = 0.01  !particles/cm^3/min, real rate is nprime*multiplicity
+
+!Particle initial conditions:
+radius_init=2.5e-6
+radius_std=0.0
+kappas_init=1.2
+kappas_std=0.00
+Tp_init = 286.0
+vp_init = 0.0, 0.0, 0.0
+/

--- a/test_cases/pi_chamber/params.in
+++ b/test_cases/pi_chamber/params.in
@@ -90,10 +90,10 @@ rad_Fcb = 0.0    !Net radiative flux at cloud (or domain) base
 !Set the paths for code I/O. Must be on the scratch directory, not AFS!
 &path_names
 
-path_seed="/scratch365/PATH_TO_SCRATCH/"
-path_part="/scratch365/PATH_TO_SCRATCH/part.le.cou002"
-path_res= "/scratch365/PATH_TO_SCRATCH/u.le.cou002"
-path_ran= "/scratch365/PATH_TO_SCRATCH/u.le.cou000"
+path_seed="PATH_TO_SCRATCH/pi_chamber/"
+path_part="PATH_TO_SCRATCH/pi_chamber/part.le.cou002"
+path_res= "PATH_TO_SCRATCH/pi_chamber/u.le.cou002"
+path_ran= "PATH_TO_SCRATCH/pi_chamber/u.le.cou000"
 
 /
 

--- a/test_cases/pi_chamber/pi_chamber.run
+++ b/test_cases/pi_chamber/pi_chamber.run
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+group_storage=/afs/crc.nd.edu/group/RichterLab
+
+#$ -M YOUR_EMAIL@nd.edu
+#$ -m n
+#$ -pe mpi-16 64
+#$ -q *@@richter
+#$ -N test_case_pi_chamber
+#$ -j y
+
+case=pi_chamber
+time=0000000
+runout=$case.out.$time
+
+datadir=PATH_TO_SCRATCH/$case
+homedir=PATH_TO_CODE/test_cases/$case
+
+# create the directory for the particle tracking output.
+mkdir -p $datadir/particle_traj
+
+# copy the pi chamber's restart file into the data directory.
+cp -f $group_storage/test_cases/$case/u.le.cou000 $datadir/u.le.cou000
+
+cd $homedir
+
+module load mvapich2
+module load intel
+module load netcdf
+
+imachine=0
+echo $imachine > ./mach.file
+echo $datadir >> ./mach.file
+
+mpirun -n 64 $homedir/../../lesmpi.a $homedir/params.in > $datadir/$runout

--- a/test_cases/spray/params.in
+++ b/test_cases/spray/params.in
@@ -1,0 +1,138 @@
+
+!Time step information
+&step_params
+iti=0          !Time step to begin
+itmax=100000   !Max number of time steps
+imean=100    !Number of time steps between writing mean profiles to output log file
+ihst=50     !Number of time steps between writing profiles to history file
+itape=10000  !Number of time steps before opening new history file and writing full 3D volumes
+i_viz=1000   !Time steps between writing to viz file
+itn = 0  !Index for "u.le.cou001" files
+max_time = 4000  !Code will stop at the next itape after this time (in seconds) has been exceeded
+/
+
+!Flags for various features
+&flags
+ismlt=0, ifree=0, iradup=0, iupwnd=0
+ibuoy=0, ifilt=0, itcut=1, isubs=0, ibrcl=0, iocean=0
+method=3, idebug=1, ivis0=1, ifix_dt=0, new_vis=-1
+isfc = 1, 1  ! isfc = 0 sets surface flux (qstar), isfc = 1 sets surface condition (Dirichlet through tsfcc)
+iz_space=0, ! 0 = uniform dz, 1 = top/bottom mirror stretched ("channel"), 2 = "open channel", 3 = PBL with stretching at surface and at zi
+iDNS = 0
+ifields = 0  ! if set to 1, reads the initial condition from path_ran below; otherwise calls subroutine random
+ihurr = 1  !If set to 1, includes the hurricane forcings from Bryan et al. (2017) BLM and according to dvdr and hurr_rad below
+ilin = 1   !1 means linear interpolation for particle, 6th order otherwise
+icouple=1
+iTcouple=1
+iHcouple=1  !iHcouple also controls TE couple
+ievap=1
+ineighbor=0
+icoalesce=0
+ipart_method=2   !1 = same RK3 as flow, 2 = backward Euler
+ipartdiff = 1
+inewpart = 4  !1 = new particles have initial conditions defined below, random location in domain; 2 = same, but normal distributions of radius and kappa_s, given by radius_std and kappas_std; 3 = special setup for C-FOG and double lognormal of different type; 4 = crude sea spray setup
+icase = 4  !Special additions for certain cases. 3 = setup for C-FOG, 4 = steady state LES sea spray setup
+isfs = 2   !isfs=1 is simple random walk, isfs=2 is Weil et al. (2004) particle subgrid
+iexner = 0  !iexner = 1 applies a correction to part%Tf to account for conversion b/w potential temp and temp. (need in PBL)
+ilongwave = 0   !Use simple longwave radiation scheme when clouds/fog present
+inetcdf = 1  !Set to 1 to output history and histogram data to netcdf format, otherwise original binary format
+iviznetcdf = 1  !Set to 1 to slice viz files to netcdf format (WARNING: it's been a long time since the original have been used)
+ihumiditycontrol = 0  !Adaptive humidity source/sink (used for Pi Chamber; subroutine humidity_control)
+ireintro=1   !Aerosol injection
+itrajout=0   !Write the particle trajectory files. Needs a directory within the scratch space, and each processor writes a file (requires postprocessing to stitch together)
+/
+
+!Grid and domain parameters
+&grid_params
+ncpu_s=8
+
+!Time step
+cfl = 0.8
+dt_new = 0.05
+
+!Use for DNS:
+Uo = 0.0  !Sets the magnitude of the top and bottom plate velocities (Couette flow -- assumes equal and opposite)
+Ttop(1) = 280.0, 100.0  !Currently this should be (temperature, relative humidity) (used in DNS)
+Tbot(1) = 299.0, 100.0  !Currently this should be (temperature, relative humidity) (used in DNS)
+
+!Use for LES:
+qstar = 0.2, 0.2  !Surface fluxes of (temperature, humidity) (used for LES and DNS)
+tsfcc = 302.65, 100.0    !Surface conditions of (temp, humidity) (used for LES) -- make sure tsfcc is gt than t00 for both isfc=0 or 1
+
+surf_RH = 100.0
+surf_temp = 282.0  !Only use this when changing the surface temperature in time! Otherwise set tsfcc
+
+psurf = 101325  !Pa -- nominal surface pressure, for use in the definition of potential temp
+
+ugcont = 0.0   !The initial u-velocity in the field
+vgcont = 80.0   !The initial v-velocity
+dvdr = -1.6e-3  !Change in v with hurricane radius
+hurr_rad = 40.0e3  ! Hurricane radius
+
+dpdx = 0.0  !The pressure gradient for channel flow (gets put into u_geo for DNS)
+
+Swall = 0  !Set the CONSTANT humidity sink to use if ihumiditycontrol = 0
+
+zi = 256.0  !This has to do with grid stretching; make equal to zl for iz_space = 1,2; zi is inversion height for iz_space = 3
+zl = 256.0
+xl = 512.0
+yl = 512.0
+
+zw1 = 4.0  !The first grid point; only used if stretched grid
+
+!Radiation parameters
+rad_kappa = 120.0  !The absorptivity in the radiation expression (see Larson et al. 2007)
+rad_Fct = 60.0    !Net radiative flux at cloud (or domain) top
+rad_Fcb = 0.0    !Net radiative flux at cloud (or domain) base
+
+/
+
+!Set the paths for code I/O. Must be on the scratch directory, not AFS!
+&path_names
+path_seed="PATH_TO_SCRATCH/spray/"
+path_part="PATH_TO_SCRATCH/spray/part.le.cou003"
+path_res="PATH_TO_SCRATCH/spray/u.le.cou003"
+path_ran="PATH_TO_SCRATCH/spray/u.le.cou000"
+/
+
+
+!Material and particle properties and other constants
+&constants
+grav = 9.81
+t00 = 273.0 !Reference temp for buoyancy
+fcor = 1.0e-4  !Coriolis parameter
+zo = 0.002844       !Roughness height (for LES)
+zos = 3.088e-08       !Scalar roughness height (for LES)
+
+!Air phase:
+rhoa=1.0
+nuf=1.57e-5  !m^2/s
+Cpa=1006.0  !J/kg-K
+Pra = 0.715
+Sc = 0.615
+Rd = 286.9     !J/kg-K  dry air gas constant
+
+!Particles:
+tnumpart = 1
+mult_init = 1.0e9
+rhow=1000.0  !kg/m^3
+rhos = 2000.0 !Density of salt, kg/m^3
+part_grav = 0,0,-9.81
+Cpp = 4179.0  !J/kg-K
+Mw = 0.018015  !kg/mol
+Ru = 8.3144    !J/mol-K Universal gas constant
+Ms = 0.05844  !kg/mol: molecular weight of salt
+Sal = 0.034  !INITIAL salinity in kg/kg
+Gam = 7.28e-2
+Ion = 2.0
+
+nprime = 0.01  !particles/cm^3/min, real rate is nprime*multiplicity
+
+!Particle initial conditions:
+radius_init=2.0e-7
+radius_std=0.0
+kappas_init=1.2
+kappas_std=0.00
+Tp_init = 290.0
+vp_init = 0.0, 0.0, 0.0
+/

--- a/test_cases/spray/spray.run
+++ b/test_cases/spray/spray.run
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+group_storage=/afs/crc.nd.edu/group/RichterLab
+
+#$ -M YOUR_EMAIL@nd.edu
+#$ -m n
+#$ -pe mpi-16 64
+#$ -q *@@richter
+#$ -N test_case_spray
+#$ -j y
+
+case=spray
+time=0000000
+runout=$case.out.$time
+
+datadir=PATH_TO_SCRATCH/$case
+homedir=PATH_TO_CODE/test_cases/$case
+
+# create the directory for the output.
+mkdir -p $datadir
+
+cd $homedir
+
+module load mvapich2
+module load intel
+module load netcdf
+
+imachine=0
+echo $imachine > ./mach.file
+echo $datadir >> ./mach.file
+
+mpirun -n 64 $homedir/../../lesmpi.a $homedir/params.in > $datadir/$runout


### PR DESCRIPTION
Primary changes:

* Updated the pi chamber test case to start from a restart file.  Updated the run script to prepare the output directory (copy the restart in, create the particles sub-directory).
* Added new test cases (cfog, channel, fatima, spray).  Default run scripts were created.
* Checked in the MATLAB postprocessing scripts under a generic, non-tutorial name

You should be able run [the tutorials on the wiki](https://richterlab.miraheze.org/wiki/Simulation_Tutorials) without issue using this branch.

I recommend merging with rebase.  This should be merged after the `debug_build_variables` branch since it is based off of it.