### PR TITLE
Configure timing output

### DIFF
--- a/les.F
+++ b/les.F
@@ -396,9 +396,9 @@ c
 c -------- update particles
 c
          if (ipart_method .eq. 1) then
-         call start_phase(measurement_id_particles)
+         call start_phase(measurement_id_particle_solver)
          call particle_update_rk3(it,istage)
-         call end_phase(measurement_id_particles)
+         call end_phase(measurement_id_particle_solver)
          end if
 
 
@@ -424,9 +424,9 @@ c
 
       if (ipart_method .eq. 2) then
 
-         call start_phase(measurement_id_particles)
+         call start_phase(measurement_id_particle_solver)
          call particle_update_BE(it)
-         call end_phase(measurement_id_particles)
+         call end_phase(measurement_id_particle_solver)
 
       end if
 

--- a/les.F
+++ b/les.F
@@ -402,21 +402,19 @@ c
          end if
 
 
+      call start_phase(measurement_id_io_histograms)
       if(l_root) then
          if (inetcdf .eq. 1) then
-           call start_phase(measurement_id_io_histograms)
            if(mhis  .and. istage .eq. 1 .and. mtape)  then
               call close_histog_netcdf
            endif
-           call end_phase(measurement_id_io_histograms)
          else
-            call start_phase(measurement_id_io_histograms)
             if(mhis  .and. istage .eq. 1 .and. mtape) then
               call close_histograms
             end if
-            call end_phase(measurement_id_io_histograms)
          end if
       endif
+      call end_phase(measurement_id_io_histograms)
 c
  8999 continue
 
@@ -436,15 +434,15 @@ c
       !part of RK scheme
       if (icoalesce) then
 
-         call start_phase(measurement_id_particles)
+         call start_phase(measurement_id_particle_coalesce)
          call particle_coalesce
-         call end_phase(measurement_id_particles)
+         call end_phase(measurement_id_particle_coalesce)
 
       end if
 
       if (ipartdiff) then
 
-        call start_phase(measurement_id_particles)
+        call start_phase(measurement_id_particle_diff)
         if (isfs == 2) then
            !Call Weil et al. (2004) Lagrangian stochastic model
            call SFS_velocity
@@ -452,23 +450,26 @@ c
            !Call stochastic model for the position based on vis_s
            call SFS_position
         end if
-        call end_phase(measurement_id_particles)
+        call end_phase(measurement_id_particle_diff)
 
       end if
 
       if (ireintro) then
-         call start_phase(measurement_id_particles)
+         call start_phase(measurement_id_particle_reintro)
          call particle_reintro(it)
-         call end_phase(measurement_id_particles)
+         call end_phase(measurement_id_particle_reintro)
       end if
 
       if (mhis) then
-         call start_phase(measurement_id_particles)
+         call start_phase(measurement_id_io_histograms)
          call radius_histogram
+         call end_phase(measurement_id_io_histograms)
+
+         call start_phase(measurement_id_io_traj)
          if (itrajout) then
          call particle_write_traj(it)
          end if
-         call end_phase(measurement_id_particles)
+         call end_phase(measurement_id_io_traj)
       end if
 
 #ifdef TECIO

--- a/measurement.f90
+++ b/measurement.f90
@@ -1022,10 +1022,17 @@ module profiling
          measurement_id_io_viz, &
 
          ! Time spent advecting particles with the computed flow.
-         measurement_id_particles, &
+         measurement_id_particle_solver, &
          measurement_id_particle_reintro, &
          measurement_id_particle_diff, &
          measurement_id_particle_coalesce, &
+         measurement_id_particle_fill_ext, &
+         measurement_id_particle_loop, &
+         measurement_id_particle_bcs, &
+         measurement_id_particle_exchange, &
+         measurement_id_particle_coupling, &
+         measurement_id_particle_stats, &
+         measurement_id_particle_ztox, &
 
          ! Time spent setting the simulation up.
          measurement_id_setup, &
@@ -1074,10 +1081,17 @@ contains
         measurement_id_io_pressure            = create_phase( "I/O - pressure field" )
         measurement_id_io_tecio               = create_phase( "I/O - TecIO" )
         measurement_id_io_viz                 = create_phase( "I/O - viz" )
-        measurement_id_particles              = create_phase( "particles" )
+        measurement_id_particle_solver        = create_phase( "particle_solver" )
         measurement_id_particle_reintro       = create_phase( "particle_reintro" )
         measurement_id_particle_diff          = create_phase( "particle_diff" )
         measurement_id_particle_coalesce      = create_phase( "particle_coalesce" )
+        measurement_id_particle_fill_ext      = create_phase( "particle_fill_ext" )
+        measurement_id_particle_loop          = create_phase( "particle_loop" )
+        measurement_id_particle_bcs           = create_phase( "particle_bcs" )
+        measurement_id_particle_exchange      = create_phase( "particle_exchange" )
+        measurement_id_particle_coupling      = create_phase( "particle_coupling" )
+        measurement_id_particle_ztox          = create_phase( "particle_ztox" )
+        measurement_id_particle_stats         = create_phase( "particle_stats" )
         measurement_id_setup                  = create_phase( "setup" )
         measurement_id_solver                 = create_phase( "solver" )
         measurement_id_timestepping_loop      = create_phase( "solver time stepping loop" )
@@ -1108,10 +1122,17 @@ contains
                                 duration_io_pressure, &
                                 duration_io_tecio, &
                                 duration_io_viz, &
-                                duration_particles, &
+                                duration_particle_solver, &
                                 duration_particle_reintro, &
                                 duration_particle_diff, &
                                 duration_particle_coalesce, &
+                                duration_particle_fill_ext, &
+                                duration_particle_loop, &
+                                duration_particle_bcs, &
+                                duration_particle_exchange, &
+                                duration_particle_coupling, &
+                                duration_particle_ztox, &
+                                duration_particle_stats, &
                                 duration_setup, &
                                 duration_solver, &
                                 duration_timestepping_loop
@@ -1145,10 +1166,17 @@ contains
         duration_io_pressure            = get_duration( measurement_id_io_pressure )
         duration_io_tecio               = get_duration( measurement_id_io_tecio )
         duration_io_viz                 = get_duration( measurement_id_io_viz )
-        duration_particles              = get_duration( measurement_id_particles )
+        duration_particle_solver        = get_duration( measurement_id_particle_solver )
         duration_particle_reintro       = get_duration( measurement_id_particle_reintro )
         duration_particle_diff          = get_duration( measurement_id_particle_diff )
         duration_particle_coalesce      = get_duration( measurement_id_particle_coalesce )
+        duration_particle_fill_ext      = get_duration( measurement_id_particle_fill_ext )
+        duration_particle_loop          = get_duration( measurement_id_particle_loop )
+        duration_particle_bcs           = get_duration( measurement_id_particle_bcs )
+        duration_particle_exchange      = get_duration( measurement_id_particle_exchange )
+        duration_particle_coupling      = get_duration( measurement_id_particle_coupling )
+        duration_particle_ztox          = get_duration( measurement_id_particle_ztox )
+        duration_particle_stats         = get_duration( measurement_id_particle_stats )
         duration_setup                  = get_duration( measurement_id_setup )
         duration_solver                 = get_duration( measurement_id_solver )
         duration_timestepping_loop      = get_duration( measurement_id_timestepping_loop )
@@ -1182,7 +1210,7 @@ contains
         !       for all related routines.
         !
         particles_duration = ( &
-             duration_particles + &
+             duration_particle_solver + &
              duration_particle_reintro + &
              duration_particle_diff + &
              duration_particle_coalesce &
@@ -1216,8 +1244,8 @@ contains
              duration_eddy_viscosity_and_bcs, duration_timestepping_loop )
         call print_duration( file_unit, "              Humidity control:              ", &
              duration_humidity, duration_timestepping_loop )
-        call print_duration( file_unit, "              Particles:                     ", &
-             duration_particles, duration_timestepping_loop )
+        call print_duration( file_unit, "              Particle solver:               ", &
+             particles_duration, duration_timestepping_loop )
         call print_duration( file_unit, "              Writing outputs:               ", &
              io_duration, duration_timestepping_loop )
 
@@ -1231,6 +1259,22 @@ contains
              duration_particle_diff, particles_duration )
         call print_duration( file_unit, "          particle_coalesce:                   ", &
              duration_particle_coalesce, particles_duration )
+        call print_duration( file_unit, "          particle_solver:                     ", &
+             duration_particle_solver, particles_duration )
+        call print_duration( file_unit, "               particle_fill_ext:                   ", &
+             duration_particle_fill_ext, duration_particle_solver )
+        call print_duration( file_unit, "               particle_loop:                       ", &
+             duration_particle_loop, duration_particle_solver )
+        call print_duration( file_unit, "               particle_bcs:                        ", &
+             duration_particle_bcs, duration_particle_solver )
+        call print_duration( file_unit, "               particle_exchange:                   ", &
+             duration_particle_exchange, duration_particle_solver )
+        call print_duration( file_unit, "               particle_coupling:                   ", &
+             duration_particle_coupling, duration_particle_solver )
+        call print_duration( file_unit, "               particle_ztox:                       ", &
+             duration_particle_ztox, duration_particle_solver )
+        call print_duration( file_unit, "               particle_stats:                      ", &
+             duration_particle_stats, duration_particle_solver )
 
         write( file_unit, "(A)" ) ""
 
@@ -1283,10 +1327,17 @@ contains
         measurement_id_io_pressure            = 0
         measurement_id_io_tecio               = 0
         measurement_id_io_viz                 = 0
-        measurement_id_particles              = 0
+        measurement_id_particle_solver        = 0
         measurement_id_particle_reintro       = 0
         measurement_id_particle_diff          = 0
         measurement_id_particle_coalesce      = 0
+        measurement_id_particle_fill_ext      = 0
+        measurement_id_particle_loop          = 0
+        measurement_id_particle_bcs           = 0
+        measurement_id_particle_exchange      = 0
+        measurement_id_particle_coupling      = 0
+        measurement_id_particle_ztox          = 0
+        measurement_id_particle_stats         = 0
         measurement_id_setup                  = 0
         measurement_id_solver                 = 0
         measurement_id_timestepping_loop      = 0

--- a/measurement.f90
+++ b/measurement.f90
@@ -1140,7 +1140,8 @@ contains
         ! Computed durations.
         real                 :: total_duration, &
                                 io_duration, &
-                                particles_duration
+                                particles_duration, &
+                                flow_duration
 
         character, parameter :: newline = new_line( "a" )
 
@@ -1204,11 +1205,6 @@ contains
              duration_io_viz &
              )
 
-        !
-        ! NOTE: It is assumed that the granularity of measurements for particle
-        !       advection will increase and this provides an aggregate time
-        !       for all related routines.
-        !
         particles_duration = ( &
              duration_particle_solver + &
              duration_particle_reintro + &
@@ -1216,64 +1212,68 @@ contains
              duration_particle_coalesce &
              )
 
+        flow_duration = ( &
+             duration_flow_solve_1 + &
+             duration_flow_solve_p + &
+             duration_flow_solve_2 + &
+             duration_eddy_viscosity_and_bcs + &
+             duration_humidity &
+             )
+
         write( file_unit, "(A,2A)" ) "Measurements report:", newline
 
         write( file_unit, "(A,2A)" )    "  Program run-time:", newline
         call print_duration( file_unit, "      Total:                         ", &
              duration_solver, total_duration )
+
         write( file_unit, "(A)" ) ""
 
-        call print_duration( file_unit, "      Solver:                        ", &
-             duration_solver, total_duration )
-        call print_duration( file_unit, "          Setup:                         ", &
+        call print_duration( file_unit, "      Setup:                         ", &
              duration_setup, duration_solver )
 
         write( file_unit, "(A)" ) ""
 
-        call print_duration( file_unit, "          Time stepping:                 ", &
-             duration_timestepping_loop, duration_solver )
-        call print_duration( file_unit, "              Derivatives:                   ", &
-             duration_derivatives, duration_timestepping_loop )
-        call print_duration( file_unit, "              Flow comp1:                    ", &
-             duration_flow_solve_1, duration_timestepping_loop )
-        call print_duration( file_unit, "              Flow comp_p:                   ", &
-             duration_flow_solve_p, duration_timestepping_loop )
-        call print_duration( file_unit, "              Flow comp2:                    ", &
-             duration_flow_solve_2, duration_timestepping_loop )
-        call print_duration( file_unit, "              Eddy viscosity/BCs:            ", &
-             duration_eddy_viscosity_and_bcs, duration_timestepping_loop )
-        call print_duration( file_unit, "              Humidity control:              ", &
-             duration_humidity, duration_timestepping_loop )
-        call print_duration( file_unit, "              Particle solver:               ", &
-             particles_duration, duration_timestepping_loop )
-        call print_duration( file_unit, "              Writing outputs:               ", &
-             io_duration, duration_timestepping_loop )
+        call print_duration( file_unit, "      Flow solver:                   ", &
+             flow_duration, total_duration )
+
+        call print_duration( file_unit, "          get_derv:                      ", &
+             duration_derivatives, flow_duration )
+        call print_duration( file_unit, "          comp1:                         ", &
+             duration_flow_solve_1, flow_duration )
+        call print_duration( file_unit, "          comp_p:                        ", &
+             duration_flow_solve_p, flow_duration )
+        call print_duration( file_unit, "          comp2:                         ", &
+             duration_flow_solve_2, flow_duration )
+        call print_duration( file_unit, "          Eddy viscosity/BCs:            ", &
+             duration_eddy_viscosity_and_bcs, flow_duration )
+        call print_duration( file_unit, "          Humidity control:              ", &
+             duration_humidity, flow_duration )
 
         write( file_unit, "(A)" ) ""
 
-        call print_duration( file_unit, "      Particles:                           ", &
+        call print_duration( file_unit, "      Particles:                     ", &
              particles_duration, duration_solver )
-        call print_duration( file_unit, "          particle_reintro:                    ", &
+        call print_duration( file_unit, "          particle_reintro:              ", &
              duration_particle_reintro, particles_duration )
-        call print_duration( file_unit, "          particle_diff:                       ", &
+        call print_duration( file_unit, "          particle_diff:                 ", &
              duration_particle_diff, particles_duration )
-        call print_duration( file_unit, "          particle_coalesce:                   ", &
+        call print_duration( file_unit, "          particle_coalesce:             ", &
              duration_particle_coalesce, particles_duration )
-        call print_duration( file_unit, "          particle_solver:                     ", &
+        call print_duration( file_unit, "          particle_solver:               ", &
              duration_particle_solver, particles_duration )
-        call print_duration( file_unit, "               particle_fill_ext:                   ", &
+        call print_duration( file_unit, "               particle_fill_ext:              ", &
              duration_particle_fill_ext, duration_particle_solver )
-        call print_duration( file_unit, "               particle_loop:                       ", &
+        call print_duration( file_unit, "               particle_loop:                  ", &
              duration_particle_loop, duration_particle_solver )
-        call print_duration( file_unit, "               particle_bcs:                        ", &
+        call print_duration( file_unit, "               particle_bcs:                   ", &
              duration_particle_bcs, duration_particle_solver )
-        call print_duration( file_unit, "               particle_exchange:                   ", &
+        call print_duration( file_unit, "               particle_exchange:              ", &
              duration_particle_exchange, duration_particle_solver )
-        call print_duration( file_unit, "               particle_coupling:                   ", &
+        call print_duration( file_unit, "               particle_coupling:              ", &
              duration_particle_coupling, duration_particle_solver )
-        call print_duration( file_unit, "               particle_ztox:                       ", &
+        call print_duration( file_unit, "               particle_ztox:                  ", &
              duration_particle_ztox, duration_particle_solver )
-        call print_duration( file_unit, "               particle_stats:                      ", &
+        call print_duration( file_unit, "               particle_stats:                 ", &
              duration_particle_stats, duration_particle_solver )
 
         write( file_unit, "(A)" ) ""

--- a/particles.f90
+++ b/particles.f90
@@ -3095,6 +3095,7 @@ CONTAINS
       use pars
       use con_data
       use con_stats
+      use profiling
       implicit none
       include 'mpif.h'
 


### PR DESCRIPTION
After adding the timing output tools, this PR applies it to the particle solver in particular, and organizes the output in a nice way. 