### PR TITLE
Post-Processing Update

### DIFF
--- a/postprocessing/history_postprocessing.m
+++ b/postprocessing/history_postprocessing.m
@@ -46,7 +46,7 @@ zu = ncread(fname,'zu'); %"zu" is the vertical grid points at the locations whic
 %1. Animate
 
 Nt = length(time); %Number of time steps
-stride = 3; %Don't necessarily want to animate each frame
+stride = 10; %Don't necessarily want to animate each frame
 figure(3)
 for i=1:stride:Nt
 

--- a/postprocessing/history_postprocessing.m
+++ b/postprocessing/history_postprocessing.m
@@ -46,12 +46,12 @@ zu = ncread(fname,'zu'); %"zu" is the vertical grid points at the locations whic
 %1. Animate
 
 Nt = length(time); %Number of time steps
-stride = 10; %Don't necessarily want to animate each frame
+stride = 3; %Don't necessarily want to animate each frame
 figure(3)
 for i=1:stride:Nt
 
     figure(3); clf
-    plot(qxym(:,i),zu(:,i),'linewidth',2)
+    plot(qxym(:,i),zu(:),'linewidth',2)
     xlabel('qv [kg/kg]')
     ylabel('z [m]')
     drawnow
@@ -59,6 +59,7 @@ for i=1:stride:Nt
 end
 
 
+%%
 %2. Plot as a time-height contour
 Nz = length(zu(:,1)); %Number of u-level grid points in z
 
@@ -73,7 +74,7 @@ contourf(T,Z,qxym,clevels,'edgecolor','none')
 colorbar
 title('qv [kg/kg]')
 xlabel('time [s]')
-ylabel(['z [m]'])
+ylabel('z [m]')
 
 
 %3. Perform a time average

--- a/postprocessing/quick_viz.m
+++ b/postprocessing/quick_viz.m
@@ -11,7 +11,9 @@ fps = 32;
 fname = './viz.nc';
 time = ncread(fname,'time');
 Nt = length(time);
+
 %% T_xy
+
 t_xy = ncread(fname,'t_xy');
 min_t = min(min(min(t_xy)));
 max_t = max(max(max(t_xy)));
@@ -25,7 +27,9 @@ open(vidfile)
 writeVideo(vidfile,movie1)
 close(vidfile)
 close all
+
 %% W_yz
+
 w_yz = ncread(fname,'w_yz');
 min_w = min(min(min(w_yz)));
 max_w = max(max(max(w_yz)));
@@ -39,7 +43,9 @@ open(vidfile)
 writeVideo(vidfile,movie2)
 close(vidfile)
 close all
+
 %% vmag_yz
+
 u_yz = ncread(fname,'u_yz');
 v_yz = ncread(fname,'v_yz');
 w_yz = ncread(fname,'w_yz');

--- a/postprocessing/quick_viz.m
+++ b/postprocessing/quick_viz.m
@@ -1,0 +1,61 @@
+clear; clc; close all;
+
+% This script is just the quick visualizations from viz_postprocessing.m
+% including a separate animation of the velocity magnitude on the
+% same yz plane as the vertical velocity.
+% This script requires the addon "SC - powerful image rendering"
+%
+% - Ben Roper 2024
+
+fps = 32;
+fname = './viz.nc';
+time = ncread(fname,'time');
+Nt = length(time);
+%% T_xy
+t_xy = ncread(fname,'t_xy');
+min_t = min(min(min(t_xy)));
+max_t = max(max(max(t_xy)));
+for ii = 1:Nt
+    sc(flipud((t_xy(:,:,ii))'),[min_t max_t],'cold');
+    movie1(ii) = getframe;
+end
+vidfile = VideoWriter('XY_T quick','MPEG-4');
+vidfile.FrameRate = fps;
+open(vidfile)
+writeVideo(vidfile,movie1)
+close(vidfile)
+close all
+%% W_yz
+w_yz = ncread(fname,'w_yz');
+min_w = min(min(min(w_yz)));
+max_w = max(max(max(w_yz)));
+for ii = 1:Nt
+    sc(flipud((w_yz(:,:,ii))'),[min_w max_w],'cold');
+    movie2(ii) = getframe;
+end
+vidfile = VideoWriter('YZ_W quick','MPEG-4');
+vidfile.FrameRate = fps;
+open(vidfile)
+writeVideo(vidfile,movie2)
+close(vidfile)
+close all
+%% vmag_yz
+u_yz = ncread(fname,'u_yz');
+v_yz = ncread(fname,'v_yz');
+w_yz = ncread(fname,'w_yz');
+vmag = zeros(size(u_yz));
+tic
+for ii = 1:Nt
+    vmag(:,:,ii) = sqrt((u_yz(:,:,ii).^2) + (v_yz(:,:,ii).^2) + (w_yz(:,:,ii).^2));
+    min_vmag = min(min(min(vmag)));
+    max_vmag = max(max(max(vmag)));
+    sc((vmag(:,:,ii)'),[min_vmag max_vmag],'hot')
+    movie3(ii) = getframe; 
+end
+toc
+vidfile = VideoWriter('vmag quick 32 fps','MPEG-4');
+vidfile.FrameRate = fps;
+open(vidfile)
+writeVideo(vidfile,movie3)
+close(vidfile)
+close all

--- a/postprocessing/viz_postprocessing.m
+++ b/postprocessing/viz_postprocessing.m
@@ -1,4 +1,7 @@
-
+clear
+clc
+close all
+%%
 
 %The "viz file" contains slices of velocities and scalars
 %The frequency that this is written out is governed by the "i_viz" paramater in params.in
@@ -7,15 +10,23 @@
 
 %"viz.nc" is a netCDF file which can be read using standard packages
 
+% I modified this script to save each of the animations at 32 frames per second as an mp4 file in the folder that the .m file is run in. To change
+% the framerate of all animations (and therefore the length as the number of frames is constant) change the variable called "fps" just below. To
+% change the framerate of an individual animation, change the value of vidfile.FrameRate after the animation you want to affect to the desired
+% framerate. DO NOT change the size of the figure while the animation is running as it will not write the .mp4 file. You can change the resolution
+% in the figure object to change the resolution of the animation (it will be very large by default and may not show up on screen if your monitor is
+% small)
+% 
+% - Ben Roper 2024
 
-clear
-clc
-close all
+fps = 32;
 
 fname = './viz.nc';
 
-%% Animate an xy-slice of potential temperature
+cmap = colormap("turbo"); % This makes the matlab native plots have more contrast
 
+%% Animate an xy-slice of potential temperature
+tic
 time = ncread(fname,'time');
 Nt = length(time);
 
@@ -35,22 +46,29 @@ min_t = min(min(min(t_xy)));
 max_t = max(max(max(t_xy)));
 clevels = linspace(min_t,max_t,100);
 
-figure(1)
+fig = figure('units','pixels','position',[0 0 1440 1080],'Colormap',cmap);
 for i=1:Nt
-
-    figure(1); clf
+    clf
     contourf(X,Y,t_xy(:,:,i),clevels,'edgecolor','none')
     colorbar
-    caxis([min_t max_t])
+    clim([min_t max_t])
     xlabel('x [m]')
     ylabel('y [m]')
-    drawnow
-
+    title('XY Slice of Potential Temperature')
+    axis equal
+    movie1(i) = getframe(fig);
 end
 
+vidfile = VideoWriter('XY Slice of Potential Temperature Cold 32fps','MPEG-4');
+vidfile.FrameRate = fps;
 
+open(vidfile)
+writeVideo(vidfile,movie1)
+close(vidfile)
+close all
+toc
 %% Animate yz-slice of vertical velocity [NOTE: truncates the z = 0 point to make the same size as the u, v, scalar arrays]
-
+tic
 z = ncread(fname,'zu');
 Nz = length(z);
 
@@ -63,15 +81,69 @@ min_w = min(min(min(w_yz)));
 max_w = max(max(max(w_yz)));
 clevels = linspace(min_w,max_w,100);
 
-figure(2)
-for i=1:Nt
+fig2 = figure('units','pixels','position',[0 0 1440 1080],'Colormap',cmap);
 
-    figure(2); clf
+for i=1:Nt
+    clf
     contourf(Y,Z,w_yz(:,:,i),clevels,'edgecolor','none')
     colorbar
-    caxis([min_w max_w])
+    clim([min_w max_w])
     xlabel('y [m]')
     ylabel('z [m]')
-    drawnow
-
+    title('YZ Slice of Vertical Velocity')
+    axis equal
+    movie2(i) = getframe(fig2);
 end
+
+vidfile = VideoWriter('YZ Slice of Vertical Velocity Cold 32fps','MPEG-4');
+vidfile.FrameRate = fps;
+
+open(vidfile)
+writeVideo(vidfile,movie2)
+close(vidfile)
+
+close all
+toc
+
+%% QUICK RENDERS
+
+% the following two animations will be pixelated and square, but will
+% animate much faster. To use this part of the script, the add on titled
+% "SC - powerful image rendering" must be installed. After install,
+% uncomment the code below and run the sections
+%
+% - Ben Roper 2024
+
+%% Quick render of t_xy
+% tic
+% 
+% for ii = 1:Nt
+%     sc(flipud((t_xy(:,:,ii))'),[min_t max_t],'cold');
+%     movie4(ii) = getframe;
+% end
+% 
+% vidfile = VideoWriter('XY_T Cold 32 fps','MPEG-4');
+% vidfile.FrameRate = fps;
+% 
+% open(vidfile)
+% writeVideo(vidfile,movie4)
+% close(vidfile)
+% close all
+% toc
+
+%% Quick render of w_yz
+% tic
+% 
+% for ii = 1:Nt
+%     sc(  flipud((w_yz(:,:,ii))')  ,[min_w max_w],'cold');
+%     movie3(ii) = getframe;
+% end
+% 
+% vidfile = VideoWriter('YZ_W Cold 32 fps','MPEG-4');
+% vidfile.FrameRate = fps;
+% 
+% open(vidfile)
+% writeVideo(vidfile,movie3)
+% close(vidfile)
+% close all
+% toc


### PR DESCRIPTION
These are the versions of the post-processing files I have been using this summer. These are the changes:

`history_postprocessing.m`:
- Fixed a bug that prevented figure 3 from rendering
`viz_postprocessing.m`:
- Added code to save each animation as a .mp4 file in whatever folder the script is ran in
- Added variable frame rate
- Changed figure render size to allow for higher quality
- Changed the figure color map so that animations have greater contrast
- Added timing so that the length each animation takes to render is printed in the command window
- Added separate renders of the animations that use the MATLAB add on "SC - powerful image rendering"

The new "quick renders" can render the same data in ~ 1 minute on my machine (when the regular animations take up to 10 minutes). They are pixelated and forced in a square aspect ratio, but given the speed at which they render, it is well worth it. I have also added the script `quick_viz.m` that only does these quick renders. The same things are rendered with the addition of a velocity magnitude animation with a different color palette.